### PR TITLE
build(docker): use the project version as the docker image tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,13 +28,6 @@ jobs:
         java-version: 11
         gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
         gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
-    - name: Define Docker Tags for SNAPSHOT
-      run: |
-        echo "DOCKER_IMAGE_TAGS=snapshot" >> $GITHUB_ENV
-    - name: Define Docker Tags for the GitHub Release (Release only)
-      if: github.event.release
-      run: |
-        echo "DOCKER_IMAGE_TAGS=latest,${{ github.event.release.tag_name }}" >> $GITHUB_ENV
     - name: Login to Docker
       run: |
         # new login with new container registry url and PAT

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -61,7 +61,7 @@
         <configuration>
           <to>
             <image>ghcr.io/camunda-community-hub/zeeqs</image>
-            <tags>${env.DOCKER_IMAGE_TAGS}</tags>
+            <tags>${project.version}</tags>
           </to>
         </configuration>
       </plugin>


### PR DESCRIPTION
Simplify the build/deploy process by using the project version as the docker image tag. 
Avoid tagging the docker image as `latest` because it seems not recommended. 