### PR TITLE
fix: avoid duplicated keys on multi-partition

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ElementInstanceStateTransition.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ElementInstanceStateTransition.kt
@@ -7,7 +7,7 @@ import javax.persistence.EnumType
 
 @Entity
 class ElementInstanceStateTransition(
-        @Id val position: Long,
+        @Id val partitionIdWithPosition: String,
         val elementInstanceKey: Long,
         @Enumerated(EnumType.STRING)
         val state: ElementInstanceState,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageCorrelation.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageCorrelation.kt
@@ -5,7 +5,7 @@ import javax.persistence.Id
 
 @Entity
 class MessageCorrelation(
-        @Id val position: Long,
+        @Id val partitionIdWithPosition: String,
         val messageKey: Long,
         val messageName: String,
         val timestamp: Long,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableUpdate.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableUpdate.kt
@@ -6,7 +6,7 @@ import javax.persistence.Lob
 
 @Entity
 class VariableUpdate(
-    @Id val position: Long,
+    @Id val partitionIdWithPosition: String,
     val variableKey: Long,
     val name: String,
     @Lob val value: String,

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -11,6 +11,7 @@ import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
 import org.springframework.stereotype.Component
 import java.time.Duration
+import javax.persistence.Id
 
 
 @Component
@@ -125,6 +126,9 @@ class HazelcastImporter(
     fun stop() {
         zeebeHazelcast?.close()
     }
+
+    private fun getPartitionIdWithPosition(metadata: Schema.RecordMetadata) =
+            "${metadata.partitionId}-${metadata.position}"
 
     private fun importProcess(process: Schema.ProcessRecord) {
         val entity = processRepository
@@ -272,7 +276,7 @@ class HazelcastImporter(
             .findById(record.metadata.position)
             .orElse(
                 ElementInstanceStateTransition(
-                    position = record.metadata.position,
+                    partitionIdWithPosition = getPartitionIdWithPosition(record.metadata),
                     elementInstanceKey = record.metadata.key,
                     timestamp = record.metadata.timestamp,
                     state = state
@@ -317,7 +321,7 @@ class HazelcastImporter(
             .findById(record.metadata.position)
             .orElse(
                 VariableUpdate(
-                    position = record.metadata.position,
+                    partitionIdWithPosition = getPartitionIdWithPosition(record.metadata),
                     variableKey = record.metadata.key,
                     name = record.name,
                     value = record.value,
@@ -588,7 +592,7 @@ class HazelcastImporter(
             .findById(record.metadata.position)
             .orElse(
                 MessageCorrelation(
-                    position = record.metadata.position,
+                    partitionIdWithPosition = getPartitionIdWithPosition(record.metadata),
                     messageKey = record.messageKey,
                     messageName = record.messageName,
                     elementInstanceKey = record.elementInstanceKey,
@@ -608,7 +612,7 @@ class HazelcastImporter(
             .findById(record.metadata.position)
             .orElse(
                 MessageCorrelation(
-                    position = record.metadata.position,
+                    partitionIdWithPosition = getPartitionIdWithPosition(record.metadata),
                     messageKey = record.messageKey,
                     messageName = record.messageName,
                     elementInstanceKey = null,


### PR DESCRIPTION
* change primary key of state transition, message correlation, and variable update from position to a compound key of partition id and position
* positions are not unique if the broker has more than one partition

closes #162 