### PR TITLE
fix: store the checksum in the database as LOB

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Process.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Process.kt
@@ -12,4 +12,4 @@ data class Process(
         @Lob val bpmnXML: String,
         val deployTime: Long,
         val resourceName: String,
-        val checksum: String)
+        @Lob val checksum: String)


### PR DESCRIPTION
* Postgres fails to import processes if the checksum contains a non-UTF8 character
* change the database type of the checksum to LOB to store it as binary data

close #257 