### PR TITLE
feat: add metadata of user task

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementMetadata.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementMetadata.kt
@@ -6,5 +6,7 @@ data class BpmnElementMetadata(
         val timerDefinition: String? = null,
         val errorCode: String? = null,
         val calledProcessId: String? = null,
-        val messageSubscriptionDefinition: MessageSubscriptionDefinition? = null
+        val messageSubscriptionDefinition: MessageSubscriptionDefinition? = null,
+        val assignee : String? = null,
+        val candidateGroups : String? = null
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
@@ -3,13 +3,8 @@ package io.zeebe.zeeqs.data.service
 import io.camunda.zeebe.model.bpmn.Bpmn
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants
-import io.camunda.zeebe.model.bpmn.instance.CatchEvent
-import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition
-import io.camunda.zeebe.model.bpmn.instance.FlowElement
-import io.camunda.zeebe.model.bpmn.instance.MessageEventDefinition
-import io.camunda.zeebe.model.bpmn.instance.SequenceFlow
-import io.camunda.zeebe.model.bpmn.instance.SubProcess
-import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition
+import io.camunda.zeebe.model.bpmn.instance.*
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition
@@ -122,7 +117,13 @@ class ProcessService(val processRepository: ProcessRepository) {
                                 )
                             }
                     else -> null
-                }
+                },
+                assignee = element
+                        .getSingleExtensionElement(ZeebeAssignmentDefinition::class.java)
+                        ?.assignee,
+                candidateGroups = element
+                        .getSingleExtensionElement(ZeebeAssignmentDefinition::class.java)
+                        ?.candidateGroups
         )
     }
 }

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -32,6 +32,8 @@ class ProcessServiceTest(
                 .startEvent("s").name("start")
                 .serviceTask("t").name("task")
                 .zeebeJobType("test")
+                .userTask("u").name("userTask")
+                .zeebeAssignee("user1").zeebeCandidateGroups("group1")
                 .endEvent("e").name("")
                 .done()
 
@@ -55,6 +57,7 @@ class ProcessServiceTest(
                 .isNotNull()
                 .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata())))
                 .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"))))
+                .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(assignee = "user1", candidateGroups = "group1"))))
                 .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata())))
     }
 

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -61,6 +61,10 @@ type BpmnElementMetadata {
     calledProcessId: String
     # the definition of the message subscription if the element is a message catch event
     messageSubscriptionDefinition: MessageSubscriptionDefinition
+    # the assignee if the element is an user task
+    assignee: String
+    # the candidateGroups if the element is an user task
+    candidateGroups: String
 }
 
 # The definition of a message subscription from a BPMN element.


### PR DESCRIPTION
## Description
I can access the following static properties of a user task. 
- the assignee
- the candidate groups

## Related issues
closes #283 