### PR TITLE
refactor: Group the user task metadata into a type

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementMetadata.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementMetadata.kt
@@ -7,6 +7,5 @@ data class BpmnElementMetadata(
         val errorCode: String? = null,
         val calledProcessId: String? = null,
         val messageSubscriptionDefinition: MessageSubscriptionDefinition? = null,
-        val assignee : String? = null,
-        val candidateGroups : String? = null
+        val userTaskAssignmentDefinition: UserTaskAssignmentDefinition? = null
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
@@ -90,6 +90,7 @@ class ProcessService(val processRepository: ProcessRepository) {
                             ?.firstOrNull()
                             ?.let { it.timeCycle ?: it.timeDate ?: it.timeDuration }
                             ?.textContent
+
                     else -> null
                 },
                 errorCode = when (element) {
@@ -98,6 +99,7 @@ class ProcessService(val processRepository: ProcessRepository) {
                             ?.firstOrNull()
                             ?.error
                             ?.errorCode
+
                     else -> null
                 },
                 calledProcessId = element
@@ -116,14 +118,17 @@ class ProcessService(val processRepository: ProcessRepository) {
                                                 ?.correlationKey
                                 )
                             }
+
                     else -> null
                 },
-                assignee = element
+                userTaskAssignmentDefinition = element
                         .getSingleExtensionElement(ZeebeAssignmentDefinition::class.java)
-                        ?.assignee,
-                candidateGroups = element
-                        .getSingleExtensionElement(ZeebeAssignmentDefinition::class.java)
-                        ?.candidateGroups
+                        ?.let {
+                            UserTaskAssignmentDefinition(
+                                    assignee = it.assignee,
+                                    candidateGroups = it.candidateGroups
+                            )
+                        }
         )
     }
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/UserTaskAssignmentDefinition.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/UserTaskAssignmentDefinition.kt
@@ -1,0 +1,6 @@
+package io.zeebe.zeeqs.data.service
+
+data class UserTaskAssignmentDefinition(
+        val assignee : String? = null,
+        val candidateGroups : String? = null
+)

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -7,6 +7,7 @@ import io.zeebe.zeeqs.data.repository.ProcessRepository
 import io.zeebe.zeeqs.data.service.BpmnElementInfo
 import io.zeebe.zeeqs.data.service.BpmnElementMetadata
 import io.zeebe.zeeqs.data.service.ProcessService
+import io.zeebe.zeeqs.data.service.UserTaskAssignmentDefinition
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
@@ -19,8 +20,8 @@ import java.time.Instant
 @SpringBootTest
 @TestConfiguration
 class ProcessServiceTest(
-    @Autowired val processService: ProcessService,
-    @Autowired val processRepository: ProcessRepository
+        @Autowired val processService: ProcessService,
+        @Autowired val processRepository: ProcessRepository
 ) {
 
     @Test
@@ -38,15 +39,15 @@ class ProcessServiceTest(
                 .done()
 
         processRepository.save(
-            Process(
-                key = processDefinitionKey,
-                bpmnProcessId = "process",
-                version = 1,
-                bpmnXML = Bpmn.convertToString(bpmn),
-                deployTime = Instant.now().toEpochMilli(),
-                resourceName = "process.bpmn",
-                checksum = "checksum"
-            )
+                Process(
+                        key = processDefinitionKey,
+                        bpmnProcessId = "process",
+                        version = 1,
+                        bpmnXML = Bpmn.convertToString(bpmn),
+                        deployTime = Instant.now().toEpochMilli(),
+                        resourceName = "process.bpmn",
+                        checksum = "checksum"
+                )
         )
 
         // when
@@ -57,7 +58,9 @@ class ProcessServiceTest(
                 .isNotNull()
                 .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata())))
                 .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"))))
-                .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(assignee = "user1", candidateGroups = "group1"))))
+                .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
+                        userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1"))))
+                )
                 .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata())))
     }
 

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -61,10 +61,8 @@ type BpmnElementMetadata {
     calledProcessId: String
     # the definition of the message subscription if the element is a message catch event
     messageSubscriptionDefinition: MessageSubscriptionDefinition
-    # the assignee if the element is an user task
-    assignee: String
-    # the candidateGroups if the element is an user task
-    candidateGroups: String
+    # the assignment definition if the element is an user task
+    userTaskAssignmentDefinition: UserTaskAssignmentDefinition
 }
 
 # The definition of a message subscription from a BPMN element.
@@ -73,4 +71,12 @@ type MessageSubscriptionDefinition {
     messageName: String
     # the correlation key of a message
     messageCorrelationKey: String
+}
+
+# The assignment definition of a BPMN user task.
+type UserTaskAssignmentDefinition {
+    # the assignee
+    assignee: String
+    # the candidate groups
+    candidateGroups: String
 }


### PR DESCRIPTION
## Description

Group the user task metadata into its own type. Both properties `assignee` and `canidateGroups` belongs to user tasks. 

Zeebe 8.2 will introduce a new property `candidateUsers`.