### PR TITLE
Get variables of process instance

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
@@ -10,4 +10,7 @@ interface VariableRepository : PagingAndSortingRepository<Variable, Long> {
 
     @Transactional(readOnly = true)
     fun findByProcessInstanceKey(processInstanceKey: Long): List<Variable>
+
+    @Transactional(readOnly = true)
+    fun findByScopeKey(scopeKey: Long): List<Variable>
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/VariableService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/VariableService.kt
@@ -1,0 +1,38 @@
+package io.zeebe.zeeqs.data.service
+
+import io.zeebe.zeeqs.data.entity.Variable
+import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
+import io.zeebe.zeeqs.data.repository.VariableRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class VariableService(
+        private val variableRepository: VariableRepository,
+        private val elementInstanceRepository: ElementInstanceRepository) {
+
+    fun getVariables(elementInstanceKey: Long, localOnly: Boolean, shadowing: Boolean): List<Variable> {
+        val localVariables = variableRepository.findByScopeKey(scopeKey = elementInstanceKey)
+
+        if (localOnly) {
+            return localVariables
+        }
+
+        val localVariableNames = localVariables.map { it.name }
+
+        return elementInstanceRepository.findByIdOrNull(elementInstanceKey)
+                ?.scopeKey
+                ?.let { flowScopeKey ->
+                    getVariables(
+                            elementInstanceKey = flowScopeKey,
+                            localOnly = false,
+                            shadowing = shadowing)
+                }
+                ?.filterNot { flowScopeVariable ->
+                    shadowing && localVariableNames.contains(flowScopeVariable.name)
+                }
+                ?.let { flowScopeVariables -> flowScopeVariables + localVariables }
+                ?: localVariables
+    }
+
+}

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -18,9 +18,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import java.time.Instant
+import javax.transaction.Transactional
 
 @SpringBootTest
 @TestConfiguration
+@Transactional
 class ProcessServiceTest(
         @Autowired val processService: ProcessService,
         @Autowired val processRepository: ProcessRepository
@@ -147,9 +149,5 @@ class ProcessServiceTest(
             assertThat(form).isNull()
         }
     }
-
-
-    @SpringBootApplication
-    class TestConfiguration
 
 }

--- a/data/src/test/kotlin/io/zeebe/zeeqs/TestConfiguration.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/TestConfiguration.kt
@@ -1,0 +1,7 @@
+package io.zeebe.zeeqs
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class TestConfiguration {
+}

--- a/data/src/test/kotlin/io/zeebe/zeeqs/VariableServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/VariableServiceTest.kt
@@ -1,0 +1,227 @@
+package io.zeebe.zeeqs
+
+import io.zeebe.zeeqs.data.entity.BpmnElementType
+import io.zeebe.zeeqs.data.entity.ElementInstance
+import io.zeebe.zeeqs.data.entity.Variable
+import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
+import io.zeebe.zeeqs.data.repository.VariableRepository
+import io.zeebe.zeeqs.data.service.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import java.util.stream.LongStream
+
+import org.assertj.core.api.Assertions.*
+import org.springframework.beans.factory.annotation.Autowired
+
+@SpringBootTest
+@TestConfiguration
+class VariableServiceTest(
+        @Autowired val variableService: VariableService,
+        @Autowired val variableRepository: VariableRepository,
+        @Autowired val elementInstanceRepository: ElementInstanceRepository
+) {
+
+    private val processInstanceKey = 10L
+    private val scope_1_1 = 11L
+    private val scope_1_2 = 12L
+    private val scope_1_3 = 13L
+    private val scope_2_1 = 21L
+
+    private val nextVariableKey = LongStream.range(1, 100).iterator()
+
+    @BeforeEach
+    fun `create variables`() {
+        createVariable(name = "global_1", value = "1", scopeKey = processInstanceKey)
+        createVariable(name = "global_2", value = "2", scopeKey = processInstanceKey)
+        createVariable(name = "var_1_1", value = "1_1", scopeKey = scope_1_1)
+        createVariable(name = "var_1_2", value = "1_2", scopeKey = scope_1_2)
+        createVariable(name = "var_1_1", value = "1_3", scopeKey = scope_1_3)
+        createVariable(name = "var_1_2", value = "1_3", scopeKey = scope_1_3)
+        createVariable(name = "var_1_3", value = "1_3", scopeKey = scope_1_3)
+        createVariable(name = "var_2_1", value = "2_1", scopeKey = scope_2_1)
+
+        createScope(key = processInstanceKey, scopeKey = null)
+        createScope(key = scope_1_1, scopeKey = processInstanceKey)
+        createScope(key = scope_1_2, scopeKey = scope_1_1)
+        createScope(key = scope_1_3, scopeKey = scope_1_2)
+        createScope(key = scope_2_1, scopeKey = processInstanceKey)
+    }
+
+    @Test
+    fun `get global variables`() {
+        // when/then
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = processInstanceKey,
+                        localOnly = true,
+                        shadowing = false))
+                .hasSize(2)
+                .extracting(Variable::name, Variable::value)
+                .contains(
+                        tuple("global_1", "1"),
+                        tuple("global_2", "2")
+                )
+    }
+
+    @Test
+    fun `get local variables`() {
+        // when/then
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_1,
+                        localOnly = true,
+                        shadowing = false))
+                .hasSize(1)
+                .extracting(Variable::name, Variable::value)
+                .contains(tuple("var_1_1", "1_1"))
+
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_2,
+                        localOnly = true,
+                        shadowing = false))
+                .hasSize(1)
+                .extracting(Variable::name, Variable::value)
+                .contains(tuple("var_1_2", "1_2"))
+
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_3,
+                        localOnly = true,
+                        shadowing = false))
+                .hasSize(3)
+                .extracting(Variable::name, Variable::value)
+                .contains(
+                        tuple("var_1_1", "1_3"),
+                        tuple("var_1_2", "1_3"),
+                        tuple("var_1_3", "1_3")
+                )
+    }
+
+    @Test
+    fun `get all variables`() {
+        // when/then
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_1,
+                        localOnly = false,
+                        shadowing = false))
+                .hasSize(3)
+                .extracting(Variable::name, Variable::value, Variable::scopeKey)
+                .contains(
+                        tuple("global_1", "1", processInstanceKey),
+                        tuple("global_2", "2", processInstanceKey),
+                        tuple("var_1_1", "1_1", scope_1_1)
+                )
+
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_2,
+                        localOnly = false,
+                        shadowing = false))
+                .hasSize(4)
+                .extracting(Variable::name, Variable::value, Variable::scopeKey)
+                .contains(
+                        tuple("global_1", "1", processInstanceKey),
+                        tuple("global_2", "2", processInstanceKey),
+                        tuple("var_1_1", "1_1", scope_1_1),
+                        tuple("var_1_2", "1_2", scope_1_2)
+                )
+
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_3,
+                        localOnly = false,
+                        shadowing = false))
+                .hasSize(7)
+                .extracting(Variable::name, Variable::value, Variable::scopeKey)
+                .contains(
+                        tuple("global_1", "1", processInstanceKey),
+                        tuple("global_2", "2", processInstanceKey),
+                        tuple("var_1_1", "1_1", scope_1_1),
+                        tuple("var_1_2", "1_2", scope_1_2),
+                        tuple("var_1_1", "1_3", scope_1_3),
+                        tuple("var_1_2", "1_3", scope_1_3),
+                        tuple("var_1_3", "1_3", scope_1_3)
+                )
+    }
+
+    @Test
+    fun `get all variables with shadowing`() {
+        // when/then
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_1,
+                        localOnly = false,
+                        shadowing = true))
+                .hasSize(3)
+                .extracting(Variable::name, Variable::value, Variable::scopeKey)
+                .contains(
+                        tuple("global_1", "1", processInstanceKey),
+                        tuple("global_2", "2", processInstanceKey),
+                        tuple("var_1_1", "1_1", scope_1_1)
+                )
+
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_2,
+                        localOnly = false,
+                        shadowing = true))
+                .hasSize(4)
+                .extracting(Variable::name, Variable::value, Variable::scopeKey)
+                .contains(
+                        tuple("global_1", "1", processInstanceKey),
+                        tuple("global_2", "2", processInstanceKey),
+                        tuple("var_1_1", "1_1", scope_1_1),
+                        tuple("var_1_2", "1_2", scope_1_2)
+                )
+
+        assertThat(
+                variableService.getVariables(
+                        elementInstanceKey = scope_1_3,
+                        localOnly = false,
+                        shadowing = true))
+                .hasSize(5)
+                .extracting(Variable::name, Variable::value, Variable::scopeKey)
+                .contains(
+                        tuple("global_1", "1", processInstanceKey),
+                        tuple("global_2", "2", processInstanceKey),
+                        tuple("var_1_1", "1_3", scope_1_3),
+                        tuple("var_1_2", "1_3", scope_1_3),
+                        tuple("var_1_3", "1_3", scope_1_3)
+                )
+    }
+
+    private fun createVariable(name: String, value: String, scopeKey: Long) {
+        variableRepository.save(
+                Variable(
+                        name = name,
+                        value = value,
+                        scopeKey = scopeKey,
+                        processInstanceKey = processInstanceKey,
+                        key = nextVariableKey.next(),
+                        position = 2L,
+                        timestamp = 1L
+                )
+        )
+    }
+
+    private fun createScope(key: Long, scopeKey: Long?) {
+        elementInstanceRepository.save(ElementInstance(
+                key = key,
+                position = 1,
+                elementId = "",
+                bpmnElementType = BpmnElementType.UNSPECIFIED,
+                processInstanceKey = processInstanceKey,
+                processDefinitionKey = 1L,
+                scopeKey = scopeKey
+        ))
+    }
+
+    @SpringBootApplication
+    class TestConfiguration
+
+}

--- a/data/src/test/kotlin/io/zeebe/zeeqs/VariableServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/VariableServiceTest.kt
@@ -15,9 +15,11 @@ import java.util.stream.LongStream
 
 import org.assertj.core.api.Assertions.*
 import org.springframework.beans.factory.annotation.Autowired
+import javax.transaction.Transactional
 
 @SpringBootTest
 @TestConfiguration
+@Transactional
 class VariableServiceTest(
         @Autowired val variableService: VariableService,
         @Autowired val variableRepository: VariableRepository,
@@ -220,8 +222,5 @@ class VariableServiceTest(
                 scopeKey = scopeKey
         ))
     }
-
-    @SpringBootApplication
-    class TestConfiguration
 
 }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceResolver.kt
@@ -5,6 +5,7 @@ import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
 import io.zeebe.zeeqs.graphql.resolvers.type.BpmnElement
 import io.zeebe.zeeqs.data.service.ProcessService
+import io.zeebe.zeeqs.data.service.VariableService
 import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -17,7 +18,8 @@ class ElementInstanceResolver(
         val elementInstanceStateTransitionRepository: ElementInstanceStateTransitionRepository,
         val timerRepository: TimerRepository,
         val processService: ProcessService,
-        val messageSubscriptionRepository: MessageSubscriptionRepository
+        val messageSubscriptionRepository: MessageSubscriptionRepository,
+        val variableService: VariableService
 ) : GraphQLResolver<ElementInstance> {
 
     fun startTime(elementInstance: ElementInstance, zoneId: String): String? {
@@ -64,6 +66,14 @@ class ElementInstanceResolver(
                 processDefinitionKey = elementInstance.processDefinitionKey,
                 elementId = elementInstance.elementId,
                 elementType = elementInstance.bpmnElementType
+        )
+    }
+
+    fun variables(elementInstance: ElementInstance, localOnly: Boolean, shadowing: Boolean): List<Variable> {
+        return variableService.getVariables(
+                elementInstanceKey = elementInstance.key,
+                localOnly = localOnly,
+                shadowing = shadowing
         )
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
@@ -3,6 +3,7 @@ package io.zeebe.zeeqs.data.resolvers
 import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
+import io.zeebe.zeeqs.data.service.VariableService
 import io.zeebe.zeeqs.graphql.resolvers.connection.UserTaskConnection
 import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension.timestampToString
 import org.springframework.data.domain.PageRequest
@@ -31,8 +32,12 @@ class ProcessInstanceResolver(
         return processInstance.endTime?.let { timestampToString(it, zoneId) }
     }
 
-    fun variables(processInstance: ProcessInstance): List<Variable> {
-        return variableRepository.findByProcessInstanceKey(processInstance.key)
+    fun variables(processInstance: ProcessInstance, globalOnly: Boolean): List<Variable> {
+        return if (globalOnly) {
+            variableRepository.findByScopeKey(scopeKey = processInstance.key)
+        } else {
+            variableRepository.findByProcessInstanceKey(processInstanceKey = processInstance.key)
+        }
     }
 
     fun jobs(processInstance: ProcessInstance, stateIn: List<JobState>, jobTypeIn: List<String>): List<Job> {

--- a/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
@@ -28,6 +28,16 @@ type ElementInstance {
     messageSubscriptions: [MessageSubscription!]
 
     element: BpmnElement!
+
+    # The variables in the scope of the element instance.
+    variables(
+        # If true, it returns only the local variables of the element instance.
+        # If false, it includes the variables from the flow scopes.
+        localOnly: Boolean = true,
+        # If a variable with the same name is set in multiple scopes and shadowing is true, it returns only the variable of the nearest scope from the element instance.
+        # If false, it returns all variables, including variables with the same name.
+        shadowing: Boolean = true
+    ): [Variable!]!
 }
 
 type ElementInstanceStateTransition {

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -14,7 +14,11 @@ type ProcessInstance {
     # the process the instance is created of
     process: Process
     # the created variables related to the process instance
-    variables: [Variable!]
+    variables(
+        # If true, it returns only the global variables of the process instance.
+        # If false, it includes the local variables from the containing scopes.
+        globalOnly: Boolean = false
+    ): [Variable!]
     # the created jobs related to the process instance
     jobs(
         stateIn: [JobState!] = [ACTIVATABLE, FAILED, COMPLETED, CANCELED, ERROR_THROWN]

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlVariableTest.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlVariableTest.kt
@@ -146,7 +146,7 @@ class ZeebeGraphqlVariableTest(
     }
 
     @Test
-    fun `should get all variables with shadowing`() {
+    fun `should get all variables of element instance with shadowing`() {
         // when/then
         graphqlAssertions.assertQuery(
                 query = """
@@ -193,7 +193,7 @@ class ZeebeGraphqlVariableTest(
     }
 
     @Test
-    fun `should get all variables`() {
+    fun `should get all variables of element instance`() {
         // when/then
         graphqlAssertions.assertQuery(
                 query = """
@@ -235,6 +235,70 @@ class ZeebeGraphqlVariableTest(
                                   "value": "local"
                                 }
                               ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                    """)
+    }
+
+    @Test
+    fun `should get all variables of process instance`() {
+        // when/then
+        graphqlAssertions.assertQuery(
+                query = """
+                    {
+                      processInstance(key: $processInstanceKey) {
+                        variables {
+                          name
+                          value
+                        }
+                      }
+                    } 
+                    """,
+                expectedResponseBody = """
+                    {
+                      "data": {
+                        "processInstance": {
+                          "variables": [
+                            {
+                              "name": "x",
+                              "value": "global"
+                            },
+                            {
+                              "name": "x",
+                              "value": "local"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                    """)
+    }
+
+    @Test
+    fun `should get all global variables`() {
+        // when/then
+        graphqlAssertions.assertQuery(
+                query = """
+                    {
+                      processInstance(key: $processInstanceKey) {
+                        variables(globalOnly: true) {
+                          name
+                          value
+                        }
+                      }
+                    } 
+                    """,
+                expectedResponseBody = """
+                    {
+                      "data": {
+                        "processInstance": {
+                          "variables": [
+                            {
+                              "name": "x",
+                              "value": "global"
                             }
                           ]
                         }

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlVariableTest.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlVariableTest.kt
@@ -1,0 +1,249 @@
+package io.zeebe.zeeqs
+
+import io.camunda.zeebe.model.bpmn.Bpmn
+import io.zeebe.zeeqs.data.entity.*
+import io.zeebe.zeeqs.data.repository.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.core.env.Environment
+import org.springframework.core.env.get
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestConfiguration
+class ZeebeGraphqlVariableTest(
+        @LocalServerPort private val port: Int,
+        @Autowired val variableRepository: VariableRepository,
+        @Autowired val elementInstanceRepository: ElementInstanceRepository,
+        @Autowired val processInstanceRepository: ProcessInstanceRepository) {
+
+    private val graphqlAssertions = GraphqlAssertions(port = port)
+
+    private val processInstanceKey = 10L
+    private val scopeKey = 20L
+
+    @BeforeEach
+    fun `create variables`() {
+        variableRepository.save(
+                Variable(
+                        name = "x",
+                        value = "global",
+                        scopeKey = processInstanceKey,
+                        processInstanceKey = processInstanceKey,
+                        key = 1L,
+                        position = 2L,
+                        timestamp = 1L
+                )
+        )
+
+        variableRepository.save(
+                Variable(
+                        name = "x",
+                        value = "local",
+                        scopeKey = scopeKey,
+                        processInstanceKey = processInstanceKey,
+                        key = 2L,
+                        position = 2L,
+                        timestamp = 1L
+                )
+        )
+    }
+
+    @BeforeEach
+    fun `create scopes`() {
+        elementInstanceRepository.save(ElementInstance(
+                key = processInstanceKey,
+                position = 1,
+                elementId = "",
+                bpmnElementType = BpmnElementType.UNSPECIFIED,
+                processInstanceKey = processInstanceKey,
+                processDefinitionKey = 1L,
+                scopeKey = null
+        ))
+
+        elementInstanceRepository.save(ElementInstance(
+                key = scopeKey,
+                position = 1,
+                elementId = "",
+                bpmnElementType = BpmnElementType.UNSPECIFIED,
+                processInstanceKey = processInstanceKey,
+                processDefinitionKey = 1L,
+                scopeKey = processInstanceKey
+        ))
+    }
+
+    @BeforeEach
+    fun `create process instance`() {
+        processInstanceRepository.save(ProcessInstance(
+                key = processInstanceKey,
+                position = 1,
+                bpmnProcessId = "",
+                version = 1,
+                processDefinitionKey = 1L,
+                parentProcessInstanceKey = null,
+                parentElementInstanceKey = null
+        ))
+    }
+
+    @Test
+    fun `should get local variables`() {
+        // when/then
+        graphqlAssertions.assertQuery(
+                query = """
+                    {
+                      processInstance(key: $processInstanceKey) {
+                        elementInstances {      
+                          key
+                          variables {
+                            name
+                            value
+                          }
+                        }
+                      }
+                    } 
+                    """,
+                expectedResponseBody = """
+                    {
+                      "data": {
+                        "processInstance": {
+                          "elementInstances": [
+                            {
+                              "key": "$processInstanceKey",
+                              "variables": [
+                                {
+                                  "name": "x",
+                                  "value": "global"
+                                }
+                              ]
+                            },
+                            {
+                              "key": "$scopeKey",
+                              "variables": [
+                                {
+                                  "name": "x",
+                                  "value": "local"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                    """)
+    }
+
+    @Test
+    fun `should get all variables with shadowing`() {
+        // when/then
+        graphqlAssertions.assertQuery(
+                query = """
+                    {
+                      processInstance(key: $processInstanceKey) {
+                        elementInstances {      
+                          key
+                          variables(localOnly: false) {
+                            name
+                            value
+                          }
+                        }
+                      }
+                    } 
+                    """,
+                expectedResponseBody = """
+                    {
+                      "data": {
+                        "processInstance": {
+                          "elementInstances": [
+                            {
+                              "key": "$processInstanceKey",
+                              "variables": [
+                                {
+                                  "name": "x",
+                                  "value": "global"
+                                }
+                              ]
+                            },
+                            {
+                              "key": "$scopeKey",
+                              "variables": [
+                                {
+                                  "name": "x",
+                                  "value": "local"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                    """)
+    }
+
+    @Test
+    fun `should get all variables`() {
+        // when/then
+        graphqlAssertions.assertQuery(
+                query = """
+                    {
+                      processInstance(key: $processInstanceKey) {
+                        elementInstances {      
+                          key
+                          variables(localOnly: false, shadowing: false) {
+                            name
+                            value
+                          }
+                        }
+                      }
+                    } 
+                    """,
+                expectedResponseBody = """
+                    {
+                      "data": {
+                        "processInstance": {
+                          "elementInstances": [
+                            {
+                              "key": "$processInstanceKey",
+                              "variables": [
+                                {
+                                  "name": "x",
+                                  "value": "global"
+                                }
+                              ]
+                            },
+                            {
+                              "key": "$scopeKey",
+                              "variables": [
+                                {
+                                  "name": "x",
+                                  "value": "global"
+                                },
+                                {
+                                  "name": "x",
+                                  "value": "local"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                    """)
+    }
+
+    @SpringBootApplication
+    class TestConfiguration
+
+}


### PR DESCRIPTION
* add a new connection from `element instance` to `variable`
  * get all local variables by default
  * if `localOnly` is `false`, get all local variables and variables from upper scopes (i.e. all visible variables)
  * if `shadowing` is `false`, get all variables, including variables with the same name
  * if `shadowing` is `true`, get all variables but exclude variables with the same name from upper scopes (i.e. variable shadowing)
* add a new option for `process instance` to return only the global variables    