### PR TITLE
Get user tasks forms as metadata

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/UserTask.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/UserTask.kt
@@ -14,8 +14,7 @@ data class UserTask(
         val elementInstanceKey: Long,
         val assignee: String?,
         val candidateGroups: String?,
-        val formKey: String?,
-        val isCamundaForm: Boolean
+        val formKey: String?
 ) {
     @Enumerated(EnumType.STRING)
     var state: UserTaskState = UserTaskState.CREATED

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementMetadata.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementMetadata.kt
@@ -7,5 +7,6 @@ data class BpmnElementMetadata(
         val errorCode: String? = null,
         val calledProcessId: String? = null,
         val messageSubscriptionDefinition: MessageSubscriptionDefinition? = null,
-        val userTaskAssignmentDefinition: UserTaskAssignmentDefinition? = null
+        val userTaskAssignmentDefinition: UserTaskAssignmentDefinition? = null,
+        val userTaskForm: UserTaskForm? = null
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/UserTaskForm.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/UserTaskForm.kt
@@ -1,4 +1,4 @@
-package io.zeebe.zeeqs.graphql.resolvers.type
+package io.zeebe.zeeqs.data.service
 
 data class UserTaskForm(
         val key: String,

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
@@ -1,10 +1,7 @@
 package io.zeebe.zeeqs.graphql.resolvers.type
 
 import graphql.kickstart.tools.GraphQLResolver
-import io.zeebe.zeeqs.data.entity.MessageSubscription
-import io.zeebe.zeeqs.data.entity.Timer
-import io.zeebe.zeeqs.data.entity.Process
-import io.zeebe.zeeqs.data.entity.ProcessInstanceState
+import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.MessageSubscriptionRepository
 import io.zeebe.zeeqs.data.repository.TimerRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
@@ -41,10 +38,11 @@ class ProcessResolver(
         return messageSubscriptionRepository.findByProcessDefinitionKeyAndElementInstanceKeyIsNull(process.key)
     }
 
-    fun elements(process: Process): List<BpmnElement> {
+    fun elements(process: Process, elementTypeIn: List<BpmnElementType>): List<BpmnElement> {
         return processService
                 .getBpmnElementInfo(process.key)
                 ?.values
+                ?.filter { elementTypeIn.isEmpty() || elementTypeIn.contains(it.elementType) }
                 ?.map { asBpmnElement(process, it) }
                 ?: emptyList()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/UserTaskResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/UserTaskResolver.kt
@@ -4,9 +4,9 @@ import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.UserTask
+import io.zeebe.zeeqs.data.service.UserTaskForm
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
-import io.zeebe.zeeqs.data.repository.UserTaskRepository
 import io.zeebe.zeeqs.data.service.ProcessService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -42,14 +42,10 @@ class UserTaskResolver(
         return userTask.formKey?.let { formKey ->
             UserTaskForm(
                     key = formKey,
-                    resource = formKey
-                            .takeIf { userTask.isCamundaForm }
-                            ?.let {
-                                processService.getForm(
-                                        processDefinitionKey = userTask.processDefinitionKey,
-                                        formKey = formKey
-                                )
-                            }
+                    resource = processService.getForm(
+                            processDefinitionKey = userTask.processDefinitionKey,
+                            formKey = formKey
+                    )
             )
         }
     }

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -62,8 +62,10 @@ type BpmnElementMetadata {
     calledProcessId: String
     # the definition of the message subscription if the element is a message catch event
     messageSubscriptionDefinition: MessageSubscriptionDefinition
-    # the assignment definition if the element is an user task
+    # the assignment definition if the element is a user task
     userTaskAssignmentDefinition: UserTaskAssignmentDefinition
+    # the user form if the element is a user task
+    userTaskForm: UserTaskForm
 }
 
 # The definition of a message subscription from a BPMN element.

--- a/graphql-api/src/main/resources/graphql/Process.graphqls
+++ b/graphql-api/src/main/resources/graphql/Process.graphqls
@@ -19,7 +19,10 @@ type Process {
     # the opened message subscriptions of the message start events of the process
     messageSubscriptions: [MessageSubscription!]
     # all BPMN elements of the process
-    elements: [BpmnElement!]
+    elements(
+        # Filter the BPMN elements by the given types. If empty, return all elements.
+        elementTypeIn: [BpmnElementType!] = []
+    ): [BpmnElement!]
     # BPMN element of the process by its id
     element(elementId: String): BpmnElement
 }

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlUserTaskTest.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlUserTaskTest.kt
@@ -84,8 +84,7 @@ class ZeebeGraphqlUserTaskTest(
                         elementInstanceKey = 1L,
                         assignee = "test",
                         candidateGroups = "[\"test-group\"]",
-                        formKey = formKey,
-                        isCamundaForm = true
+                        formKey = formKey
                 )
         )
     }

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -13,9 +13,6 @@ import io.zeebe.zeeqs.data.repository.*
 import org.springframework.stereotype.Component
 import java.time.Duration
 
-
-private const val CAMUNDA_FORM_KEY_PREFIX = "camunda-forms:bpmn:"
-
 @Component
 class HazelcastImporter(
     val hazelcastConfigRepository: HazelcastConfigRepository,
@@ -421,7 +418,6 @@ class HazelcastImporter(
         val assignee = customHeaders[Protocol.USER_TASK_ASSIGNEE_HEADER_NAME]?.stringValue
         val candidateGroups = customHeaders[Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME]?.stringValue
         val formKey = customHeaders[Protocol.USER_TASK_FORM_KEY_HEADER_NAME]?.stringValue
-        val isCamundaForm = formKey?.startsWith(CAMUNDA_FORM_KEY_PREFIX) ?: false
         return UserTask(
                 key = record.metadata.key,
                 position = record.metadata.position,
@@ -430,8 +426,7 @@ class HazelcastImporter(
                 elementInstanceKey = record.elementInstanceKey,
                 assignee = assignee,
                 candidateGroups = candidateGroups,
-                formKey = formKey?.replace(CAMUNDA_FORM_KEY_PREFIX, ""),
-                isCamundaForm = isCamundaForm
+                formKey = formKey
         )
     }
 

--- a/hazelcast-importer/src/test/kotlin/io/zeebe/zeeqs/HazelcastImporterJobTest.kt
+++ b/hazelcast-importer/src/test/kotlin/io/zeebe/zeeqs/HazelcastImporterJobTest.kt
@@ -124,8 +124,7 @@ class HazelcastImporterJobTest(
         assertThat(userTask.endTime).isNull()
         assertThat(userTask.assignee).isEqualTo("test")
         assertThat(userTask.candidateGroups).isEqualTo("""["test-group"]""")
-        assertThat(userTask.formKey).isEqualTo("form_A")
-        assertThat(userTask.isCamundaForm).isTrue()
+        assertThat(userTask.formKey).isEqualTo("camunda-forms:bpmn:form_A")
     }
 
     @SpringBootApplication


### PR DESCRIPTION
- add the property `userTaskForm` to the BPMN element metadata 
  - the form has a `formKey`
  - the form can have a `resource` (i.e. the form JSON definition)
- add an option to filter `elements` of a process by their BPMN type   