### PR TITLE
deps: Dump spring from 2.6.7 to 2.7.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,24 @@ name: Build project with Maven
 on:
   pull_request:
   schedule:
-  - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
+    - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
-    - name: Java setup
-      uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
-      with:
-        java-version: 11
-    - name: Cache
-      uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Run Maven
-      run: mvn -B clean verify com.mycila:license-maven-plugin:check
+      - name: Checkout
+        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - name: Java setup
+        uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
+        with:
+          java-version: 17
+      - name: Cache
+        uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run Maven
+        run: mvn -B clean verify com.mycila:license-maven-plugin:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,47 +10,48 @@ on:
     branches: [ master ]
   release:
     types: [ published ]
+    
 jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
-    - name: Cache
-      uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # pin@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Set up Java environment
-      uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
-      with:
-        java-version: 11
-        gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
-        gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
-    - name: Login to Docker
-      run: |
-        # new login with new container registry url and PAT
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-    - name: Deploy SNAPSHOT / Release
-      uses: camunda-community-hub/community-action-maven-release@a9e964bf56978eef9bca81551cecceebb246a8e5 # pin@v1
-      with:
-        release-version: ${{ github.event.release.tag_name }}
-        release-profile: community-action-maven-release,-jib-local,jib-multiplatform
-        nexus-usr: ${{ secrets.NEXUS_USR }}
-        nexus-psw: ${{ secrets.NEXUS_PSW }}
-        maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
-        maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
-        maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      id: release
-    - if: github.event.release
-      name: Attach artifacts to GitHub Release (Release only)
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # pin@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
-        asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
-        asset_content_type: application/zip
+      - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - name: Cache
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # pin@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up Java environment
+        uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
+        with:
+          java-version: 17
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
+          gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
+      - name: Login to Docker
+        run: |
+          # new login with new container registry url and PAT
+          echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Deploy SNAPSHOT / Release
+        uses: camunda-community-hub/community-action-maven-release@a9e964bf56978eef9bca81551cecceebb246a8e5 # pin@v1
+        with:
+          release-version: ${{ github.event.release.tag_name }}
+          release-profile: community-action-maven-release,-jib-local,jib-multiplatform
+          nexus-usr: ${{ secrets.NEXUS_USR }}
+          nexus-psw: ${{ secrets.NEXUS_PSW }}
+          maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+          maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+          maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        id: release
+      - if: github.event.release
+        name: Attach artifacts to GitHub Release (Release only)
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # pin@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
+          asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
+          asset_content_type: application/zip

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1,131 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.zeebe.zeeqs</groupId>
-    <artifactId>zeeqs-root</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>io.zeebe.zeeqs</groupId>
+        <artifactId>zeeqs-root</artifactId>
+        <version>2.6.1-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>app</artifactId>
-  <name>ZeeQS - App</name>
+    <artifactId>app</artifactId>
+    <name>ZeeQS - App</name>
 
-  <dependencies>
+    <dependencies>
 
-    <dependency>
-      <groupId>io.zeebe.zeeqs</groupId>
-      <artifactId>graphql-api</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.zeebe.zeeqs</groupId>
+            <artifactId>graphql-api</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.zeebe.zeeqs</groupId>
-      <artifactId>hazelcast-importer</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.zeebe.zeeqs</groupId>
+            <artifactId>hazelcast-importer</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <scope>runtime</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-  </dependencies>
+    </dependencies>
 
-  <build>
-    <finalName>zeeqs-${project.version}</finalName>
+    <build>
+        <finalName>zeeqs-${project.version}</finalName>
 
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.7.6</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-
-  </build>
-
-  <profiles>
-    <profile>
-      <id>jib-local</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
         <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>build-local</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>dockerBuild</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-      </build>
-    </profile>
 
-    <profile>
-      <id>jib-multiplatform</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration combine.self="append" combine.children="append">
-              <from>
-                <platforms>
-                  <platform>
-                    <architecture>amd64</architecture>
-                    <os>linux</os>
-                  </platform>
-                  <platform>
-                    <architecture>arm64</architecture>
-                    <os>linux</os>
-                  </platform>
-                </platforms>
-              </from>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>jib-local</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-local</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>dockerBuild</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>jib-multiplatform</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration combine.self="append" combine.children="append">
+                            <from>
+                                <platforms>
+                                    <platform>
+                                        <architecture>amd64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ElementInstance.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ElementInstance.kt
@@ -1,20 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class ElementInstance(
-    @Id val key: Long,
-    val position: Long,
-    val elementId: String,
-    @Enumerated(EnumType.STRING)
-    val bpmnElementType: BpmnElementType,
-    val processInstanceKey: Long,
-    val processDefinitionKey: Long,
-    val scopeKey: Long?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val elementId: String,
+        @Enumerated(EnumType.STRING)
+        val bpmnElementType: BpmnElementType,
+        val processInstanceKey: Long,
+        val processDefinitionKey: Long,
+        val scopeKey: Long?
 ) {
 
 

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Incident.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Incident.kt
@@ -1,20 +1,16 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
-import javax.persistence.Lob
+import javax.persistence.*
 
 @Entity
 class Incident(
-    @Id val key: Long,
-    val position: Long,
-    val errorType: String,
-    @Lob val errorMessage: String,
-    val processInstanceKey: Long,
-    val elementInstanceKey: Long,
-    val jobKey: Long?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val errorType: String,
+        @Lob val errorMessage: String,
+        val processInstanceKey: Long,
+        val elementInstanceKey: Long,
+        val jobKey: Long?
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Job.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Job.kt
@@ -1,17 +1,14 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class Job(
-    @Id val key: Long,
-    val position: Long,
-    val jobType: String,
-    val processInstanceKey: Long,
-    val elementInstanceKey: Long
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val jobType: String,
+        val processInstanceKey: Long,
+        val elementInstanceKey: Long
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Message.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Message.kt
@@ -1,13 +1,10 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class Message(
-        @Id val key: Long,
+        @Id @Column(name = "key_") val key: Long,
         val position: Long,
         val name: String,
         val correlationKey: String?,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscription.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscription.kt
@@ -1,20 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class MessageSubscription(
-    @Id val key: Long,
-    val position: Long,
-    val messageName: String,
-    val messageCorrelationKey: String?,
-    val processInstanceKey: Long?,
-    val elementInstanceKey: Long?,
-    val processDefinitionKey: Long?,
-    val elementId: String?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val messageName: String,
+        val messageCorrelationKey: String?,
+        val processInstanceKey: Long?,
+        val elementInstanceKey: Long?,
+        val processDefinitionKey: Long?,
+        val elementId: String?
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageVariable.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageVariable.kt
@@ -1,5 +1,6 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
@@ -8,7 +9,7 @@ import javax.persistence.Lob
 class MessageVariable(
         @Id val id: String,
         val name: String,
-        @Lob val value: String,
+        @Lob @Column(name = "value_") val value: String,
         val messageKey: Long,
         val position: Long
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Process.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Process.kt
@@ -1,12 +1,13 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
 
 @Entity
 data class Process(
-        @Id val key: Long,
+        @Id @Column(name = "key_") val key: Long,
         val bpmnProcessId: String,
         val version: Int,
         @Lob val bpmnXML: String,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ProcessInstance.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ProcessInstance.kt
@@ -1,19 +1,16 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class ProcessInstance(
-    @Id val key: Long,
-    val position: Long,
-    val bpmnProcessId: String,
-    val version: Int,
-    val processDefinitionKey: Long,
-    val parentProcessInstanceKey: Long?,
-    val parentElementInstanceKey: Long?) {
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val bpmnProcessId: String,
+        val version: Int,
+        val processDefinitionKey: Long,
+        val parentProcessInstanceKey: Long?,
+        val parentElementInstanceKey: Long?) {
 
     @Enumerated(EnumType.STRING)
     var state: ProcessInstanceState = ProcessInstanceState.ACTIVATED

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
@@ -1,20 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class Timer(
-    @Id val key: Long,
-    val position: Long,
-    val dueDate: Long,
-    var repetitions: Int,
-    val elementId: String,
-    var processInstanceKey: Long?,
-    val elementInstanceKey: Long?,
-    val processDefinitionKey: Long?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val dueDate: Long,
+        var repetitions: Int,
+        val elementId: String,
+        var processInstanceKey: Long?,
+        val elementInstanceKey: Long?,
+        val processDefinitionKey: Long?
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/UserTask.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/UserTask.kt
@@ -1,13 +1,10 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class UserTask(
-        @Id val key: Long,
+        @Id @Column(name = "key_") val key: Long,
         val position: Long,
         val processInstanceKey: Long,
         val processDefinitionKey: Long,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Variable.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Variable.kt
@@ -1,16 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
 
 @Entity
 class Variable(
-    @Id val key: Long,
-    val position: Long,
-    val name: String,
-    val processInstanceKey: Long,
-    val scopeKey: Long,
-    @Lob var value: String,
-    var timestamp: Long
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val name: String,
+        val processInstanceKey: Long,
+        val scopeKey: Long,
+        @Lob @Column(name = "value_") var value: String,
+        var timestamp: Long
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableUpdate.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableUpdate.kt
@@ -1,16 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
 
 @Entity
 class VariableUpdate(
-    @Id val partitionIdWithPosition: String,
-    val variableKey: Long,
-    val name: String,
-    @Lob val value: String,
-    val processInstanceKey: Long,
-    val scopeKey: Long,
-    val timestamp: Long
+        @Id val partitionIdWithPosition: String,
+        val variableKey: Long,
+        val name: String,
+        @Lob @Column(name = "value_") val value: String,
+        val processInstanceKey: Long,
+        val scopeKey: Long,
+        val timestamp: Long
 )

--- a/pom.xml
+++ b/pom.xml
@@ -1,386 +1,387 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <packaging>pom</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
 
-  <parent>
-    <groupId>org.camunda</groupId>
-    <artifactId>camunda-release-parent</artifactId>
-    <version>3.9.1</version>
-    <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
-  </parent>
+    <parent>
+        <groupId>org.camunda</groupId>
+        <artifactId>camunda-release-parent</artifactId>
+        <version>3.9.1</version>
+        <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
+        <relativePath/>
+    </parent>
 
-  <groupId>io.zeebe.zeeqs</groupId>
-  <artifactId>zeeqs-root</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
-  <name>ZeeQS - Root</name>
-  <description>Query API for aggregated Zeebe data</description>
+    <groupId>io.zeebe.zeeqs</groupId>
+    <artifactId>zeeqs-root</artifactId>
+    <version>2.6.1-SNAPSHOT</version>
+    <name>ZeeQS - Root</name>
+    <description>Query API for aggregated Zeebe data</description>
 
-  <modules>
-    <module>data</module>
-    <module>graphql-api</module>
-    <module>hazelcast-importer</module>
-    <module>app</module>
-  </modules>
+    <modules>
+        <module>data</module>
+        <module>graphql-api</module>
+        <module>hazelcast-importer</module>
+        <module>app</module>
+    </modules>
 
-  <properties>
-    <kotlin.version>1.8.0</kotlin.version>
+    <properties>
+        <kotlin.version>1.8.0</kotlin.version>
 
-    <zeebe.version>8.1.6</zeebe.version>
+        <zeebe.version>8.1.6</zeebe.version>
 
         <spring.boot.version>2.7.8</spring.boot.version>
 
-    <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
-    <!-- pin Hazelcast version because of spring-boot-dependencies -->
-    <version.hazelcast>5.2.1</version.hazelcast>
+        <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
+        <!-- pin Hazelcast version because of spring-boot-dependencies -->
+        <version.hazelcast>5.2.1</version.hazelcast>
 
-    <version.graphql>8.1.1</version.graphql>
-    <version.graphql.tools>6.3.0</version.graphql.tools>
+        <version.graphql>8.1.1</version.graphql>
+        <version.graphql.tools>6.3.0</version.graphql.tools>
 
-    <zeebe-test-container.version>3.5.2</zeebe-test-container.version>
-    <test-container.version>1.17.6</test-container.version>
+        <zeebe-test-container.version>3.5.2</zeebe-test-container.version>
+        <test-container.version>1.17.6</test-container.version>
 
-    <!-- release parent settings -->
-    <version.java>11</version.java>
-    <nexus.snapshot.repository>
-      https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
-    </nexus.snapshot.repository>
-    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
-    </nexus.release.repository>
+        <!-- release parent settings -->
+        <version.java>17</version.java>
+        <nexus.snapshot.repository>
+            https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
+        </nexus.snapshot.repository>
+        <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
+        </nexus.release.repository>
 
-    <!-- disable jdk8 javadoc checks on release build -->
-    <additionalparam>-Xdoclint:none</additionalparam>
+        <!-- disable jdk8 javadoc checks on release build -->
+        <additionalparam>-Xdoclint:none</additionalparam>
 
-    <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
-  </properties>
+        <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
+    </properties>
 
-  <dependencyManagement>
-    <dependencies>
-
-      <dependency>
-        <groupId>io.zeebe.zeeqs</groupId>
-        <artifactId>data</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe.zeeqs</groupId>
-        <artifactId>graphql-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe.zeeqs</groupId>
-        <artifactId>hazelcast-importer</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-bom</artifactId>
-        <version>${zeebe.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe.hazelcast</groupId>
-        <artifactId>zeebe-hazelcast-connector</artifactId>
-        <version>${hazelcast.exporter.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast</artifactId>
-        <version>${version.hazelcast}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.graphql-java-kickstart</groupId>
-        <artifactId>graphql-spring-boot-starter</artifactId>
-        <version>${version.graphql}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.graphql-java-kickstart</groupId>
-        <artifactId>graphiql-spring-boot-starter</artifactId>
-        <version>${version.graphql}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.graphql-java-kickstart</groupId>
-        <artifactId>graphql-java-tools</artifactId>
-        <version>${version.graphql.tools}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe</groupId>
-        <artifactId>zeebe-test-container</artifactId>
-        <version>${zeebe-test-container.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${test-container.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${test-container.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility-kotlin</artifactId>
-        <version>4.2.0</version>
-      </dependency>
-
-      <!-- Kotlin deps -->
-
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-common</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-reflect</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-
-    </dependencies>
-  </dependencyManagement>
-
-  <!-- common dependencies -->
-  <dependencies>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-reflect</artifactId>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
-
-    <plugins>
-
-      <plugin>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-maven-plugin</artifactId>
-        <version>${kotlin.version}</version>
-        <configuration>
-          <args>
-            <arg>-Xjsr305=strict</arg>
-          </args>
-          <compilerPlugins>
-            <plugin>spring</plugin>
-            <plugin>jpa</plugin>
-          </compilerPlugins>
-          <jvmTarget>11</jvmTarget>
-        </configuration>
+    <dependencyManagement>
         <dependencies>
-          <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-maven-allopen</artifactId>
-            <version>${kotlin.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-maven-noarg</artifactId>
-            <version>${kotlin.version}</version>
-          </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.zeeqs</groupId>
+                <artifactId>data</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.zeeqs</groupId>
+                <artifactId>graphql-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.zeeqs</groupId>
+                <artifactId>hazelcast-importer</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.camunda</groupId>
+                <artifactId>zeebe-bom</artifactId>
+                <version>${zeebe.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.hazelcast</groupId>
+                <artifactId>zeebe-hazelcast-connector</artifactId>
+                <version>${hazelcast.exporter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${version.hazelcast}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.graphql-java-kickstart</groupId>
+                <artifactId>graphql-spring-boot-starter</artifactId>
+                <version>${version.graphql}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.graphql-java-kickstart</groupId>
+                <artifactId>graphiql-spring-boot-starter</artifactId>
+                <version>${version.graphql}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.graphql-java-kickstart</groupId>
+                <artifactId>graphql-java-tools</artifactId>
+                <version>${version.graphql.tools}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe</groupId>
+                <artifactId>zeebe-test-container</artifactId>
+                <version>${zeebe-test-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${test-container.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${test-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility-kotlin</artifactId>
+                <version>4.2.0</version>
+            </dependency>
+
+            <!-- Kotlin deps -->
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+
         </dependencies>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
+    </dependencyManagement>
 
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+    <!-- common dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+    </dependencies>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
-      </plugin>
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
-        <configuration>
-          <release>11</release>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!-- Override java source version to workaround javadoc bug https://bugs.openjdk.java.net/browse/JDK-8212233 -->
-          <source>8</source>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.5.0</version>
-        <executions>
-          <execution>
-            <id>copy</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <artifactItems>
-            <artifactItem>
-              <groupId>io.zeebe.hazelcast</groupId>
-              <artifactId>zeebe-hazelcast-exporter</artifactId>
-              <version>${hazelcast.exporter.version}</version>
-              <type>jar</type>
-              <classifier>jar-with-dependencies</classifier>
-              <overWrite>true</overWrite>
-              <outputDirectory>${project.build.directory}/exporter</outputDirectory>
-              <destFileName>zeebe-hazelcast-exporter.jar</destFileName>
-            </artifactItem>
-          </artifactItems>
-          <outputDirectory>${project.build.directory}/libs</outputDirectory>
-          <overWriteReleases>false</overWriteReleases>
-          <overWriteSnapshots>true</overWriteSnapshots>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>empty-javadoc-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${basedir}/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-    </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <version>${jib-maven-plugin.version}</version>
-          <configuration>
-            <to>
-              <image>ghcr.io/camunda-community-hub/zeeqs</image>
-              <tags>${project.version}</tags>
-            </to>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>community-action-maven-release</id>
-      <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <!-- Prevent gpg from using pinentry programs -->
-              <gpgArguments>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-          </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <configuration>
+                    <args>
+                        <arg>-Xjsr305=strict</arg>
+                    </args>
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                        <plugin>jpa</plugin>
+                    </compilerPlugins>
+                    <jvmTarget>11</jvmTarget>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-noarg</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- Override java source version to workaround javadoc bug https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                    <source>8</source>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>io.zeebe.hazelcast</groupId>
+                            <artifactId>zeebe-hazelcast-exporter</artifactId>
+                            <version>${hazelcast.exporter.version}</version>
+                            <type>jar</type>
+                            <classifier>jar-with-dependencies</classifier>
+                            <overWrite>true</overWrite>
+                            <outputDirectory>${project.build.directory}/exporter</outputDirectory>
+                            <destFileName>zeebe-hazelcast-exporter.jar</destFileName>
+                        </artifactItem>
+                    </artifactItems>
+                    <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                    <overWriteReleases>false</overWriteReleases>
+                    <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${basedir}/javadoc</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
-      </build>
-    </profile>
-  </profiles>
 
-  <repositories>
-    <repository>
-      <id>zeebe</id>
-      <name>Zeebe Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>${jib-maven-plugin.version}</version>
+                    <configuration>
+                        <to>
+                            <image>ghcr.io/camunda-community-hub/zeeqs</image>
+                            <tags>${project.version}</tags>
+                        </to>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
-    <repository>
-      <id>zeebe-snapshots</id>
-      <name>Zeebe Snapshot Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+    <profiles>
+        <profile>
+            <id>community-action-maven-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
-  <scm>
-    <url>https://github.com/camunda-community-hub/zeeqs</url>
-    <connection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</connection>
-    <developerConnection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+    <repositories>
+        <repository>
+            <id>zeebe</id>
+            <name>Zeebe Repository</name>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>zeebe-snapshots</id>
+            <name>Zeebe Snapshot Repository</name>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <scm>
+        <url>https://github.com/camunda-community-hub/zeeqs</url>
+        <connection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</connection>
+        <developerConnection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <zeebe.version>8.1.6</zeebe.version>
 
-    <spring.boot.version>2.6.7</spring.boot.version>
+        <spring.boot.version>2.7.8</spring.boot.version>
 
     <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
     <!-- pin Hazelcast version because of spring-boot-dependencies -->


### PR DESCRIPTION
- dump Spring version from 2.6.7 to 2.7.8
- dump Java from 11 to 17

The new version of H2 (caused by the new version of Spring) doesn't work with the existing database schema because the columns `key` and `value` are reserved keywords. We need to change the column names to be compatible and update it to the new H2 version.