### PR TITLE
feat: Migrate to Spring-GraphQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,24 @@ name: Build project with Maven
 on:
   pull_request:
   schedule:
-  - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
+    - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
-    - name: Java setup
-      uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
-      with:
-        java-version: 11
-    - name: Cache
-      uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Run Maven
-      run: mvn -B clean verify com.mycila:license-maven-plugin:check
+      - name: Checkout
+        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - name: Java setup
+        uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
+        with:
+          java-version: 17
+      - name: Cache
+        uses: actions/cache@99d99cd262b87f5f8671407a1e5c1ddfa36ad5ba # pin@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Run Maven
+        run: mvn -B clean verify com.mycila:license-maven-plugin:check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,43 +14,43 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
-    - name: Cache
-      uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # pin@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Set up Java environment
-      uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
-      with:
-        java-version: 11
-        gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
-        gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
-    - name: Login to Docker
-      run: |
-        # new login with new container registry url and PAT
-        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-    - name: Deploy SNAPSHOT / Release
-      uses: camunda-community-hub/community-action-maven-release@a9e964bf56978eef9bca81551cecceebb246a8e5 # pin@v1
-      with:
-        release-version: ${{ github.event.release.tag_name }}
-        release-profile: community-action-maven-release,-jib-local,jib-multiplatform
-        nexus-usr: ${{ secrets.NEXUS_USR }}
-        nexus-psw: ${{ secrets.NEXUS_PSW }}
-        maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
-        maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
-        maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      id: release
-    - if: github.event.release
-      name: Attach artifacts to GitHub Release (Release only)
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # pin@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
-        asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
-        asset_content_type: application/zip
+      - uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+      - name: Cache
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # pin@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up Java environment
+        uses: actions/setup-java@e54a62b3df9364d4b4c1c29c7225e57fe605d7dd # pin@v1
+        with:
+          java-version: 17
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
+          gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE
+      - name: Login to Docker
+        run: |
+          # new login with new container registry url and PAT
+          echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Deploy SNAPSHOT / Release
+        uses: camunda-community-hub/community-action-maven-release@a9e964bf56978eef9bca81551cecceebb246a8e5 # pin@v1
+        with:
+          release-version: ${{ github.event.release.tag_name }}
+          release-profile: community-action-maven-release,-jib-local,jib-multiplatform
+          nexus-usr: ${{ secrets.NEXUS_USR }}
+          nexus-psw: ${{ secrets.NEXUS_PSW }}
+          maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR }}
+          maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
+          maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        id: release
+      - if: github.event.release
+        name: Attach artifacts to GitHub Release (Release only)
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # pin@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.release.outputs.artifacts_archive_path }}
+          asset_name: ${{ steps.release.outputs.artifacts_archive_path }}
+          asset_content_type: application/zip

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1,131 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.zeebe.zeeqs</groupId>
-    <artifactId>zeeqs-root</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>io.zeebe.zeeqs</groupId>
+        <artifactId>zeeqs-root</artifactId>
+        <version>2.6.1-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>app</artifactId>
-  <name>ZeeQS - App</name>
+    <artifactId>app</artifactId>
+    <name>ZeeQS - App</name>
 
-  <dependencies>
+    <dependencies>
 
-    <dependency>
-      <groupId>io.zeebe.zeeqs</groupId>
-      <artifactId>graphql-api</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.zeebe.zeeqs</groupId>
+            <artifactId>graphql-api</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.zeebe.zeeqs</groupId>
-      <artifactId>hazelcast-importer</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.zeebe.zeeqs</groupId>
+            <artifactId>hazelcast-importer</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <scope>runtime</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-  </dependencies>
+    </dependencies>
 
-  <build>
-    <finalName>zeeqs-${project.version}</finalName>
+    <build>
+        <finalName>zeeqs-${project.version}</finalName>
 
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.7.6</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-
-  </build>
-
-  <profiles>
-    <profile>
-      <id>jib-local</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
         <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>build-local</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>dockerBuild</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-      </build>
-    </profile>
 
-    <profile>
-      <id>jib-multiplatform</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>jib-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration combine.self="append" combine.children="append">
-              <from>
-                <platforms>
-                  <platform>
-                    <architecture>amd64</architecture>
-                    <os>linux</os>
-                  </platform>
-                  <platform>
-                    <architecture>arm64</architecture>
-                    <os>linux</os>
-                  </platform>
-                </platforms>
-              </from>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>jib-local</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-local</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>dockerBuild</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>jib-multiplatform</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration combine.self="append" combine.children="append">
+                            <from>
+                                <platforms>
+                                    <platform>
+                                        <architecture>amd64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -24,3 +24,9 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
+
+
+  # enable GraphiQL inspection tool by default
+  graphql:
+    graphiql:
+      enabled: true

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ElementInstance.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ElementInstance.kt
@@ -1,20 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class ElementInstance(
-    @Id val key: Long,
-    val position: Long,
-    val elementId: String,
-    @Enumerated(EnumType.STRING)
-    val bpmnElementType: BpmnElementType,
-    val processInstanceKey: Long,
-    val processDefinitionKey: Long,
-    val scopeKey: Long?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val elementId: String,
+        @Enumerated(EnumType.STRING)
+        val bpmnElementType: BpmnElementType,
+        val processInstanceKey: Long,
+        val processDefinitionKey: Long,
+        val scopeKey: Long?
 ) {
 
 

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Incident.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Incident.kt
@@ -1,20 +1,16 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
-import javax.persistence.Lob
+import javax.persistence.*
 
 @Entity
 class Incident(
-    @Id val key: Long,
-    val position: Long,
-    val errorType: String,
-    @Lob val errorMessage: String,
-    val processInstanceKey: Long,
-    val elementInstanceKey: Long,
-    val jobKey: Long?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val errorType: String,
+        @Lob val errorMessage: String,
+        val processInstanceKey: Long,
+        val elementInstanceKey: Long,
+        val jobKey: Long?
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Job.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Job.kt
@@ -1,17 +1,14 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class Job(
-    @Id val key: Long,
-    val position: Long,
-    val jobType: String,
-    val processInstanceKey: Long,
-    val elementInstanceKey: Long
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val jobType: String,
+        val processInstanceKey: Long,
+        val elementInstanceKey: Long
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Message.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Message.kt
@@ -1,13 +1,10 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class Message(
-        @Id val key: Long,
+        @Id @Column(name = "key_") val key: Long,
         val position: Long,
         val name: String,
         val correlationKey: String?,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscription.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageSubscription.kt
@@ -1,20 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class MessageSubscription(
-    @Id val key: Long,
-    val position: Long,
-    val messageName: String,
-    val messageCorrelationKey: String?,
-    val processInstanceKey: Long?,
-    val elementInstanceKey: Long?,
-    val processDefinitionKey: Long?,
-    val elementId: String?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val messageName: String,
+        val messageCorrelationKey: String?,
+        val processInstanceKey: Long?,
+        val elementInstanceKey: Long?,
+        val processDefinitionKey: Long?,
+        val elementId: String?
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageVariable.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/MessageVariable.kt
@@ -1,5 +1,6 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
@@ -8,7 +9,7 @@ import javax.persistence.Lob
 class MessageVariable(
         @Id val id: String,
         val name: String,
-        @Lob val value: String,
+        @Lob @Column(name = "value_") val value: String,
         val messageKey: Long,
         val position: Long
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Process.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Process.kt
@@ -1,12 +1,13 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
 
 @Entity
 data class Process(
-        @Id val key: Long,
+        @Id @Column(name = "key_") val key: Long,
         val bpmnProcessId: String,
         val version: Int,
         @Lob val bpmnXML: String,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ProcessInstance.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/ProcessInstance.kt
@@ -1,19 +1,16 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class ProcessInstance(
-    @Id val key: Long,
-    val position: Long,
-    val bpmnProcessId: String,
-    val version: Int,
-    val processDefinitionKey: Long,
-    val parentProcessInstanceKey: Long?,
-    val parentElementInstanceKey: Long?) {
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val bpmnProcessId: String,
+        val version: Int,
+        val processDefinitionKey: Long,
+        val parentProcessInstanceKey: Long?,
+        val parentElementInstanceKey: Long?) {
 
     @Enumerated(EnumType.STRING)
     var state: ProcessInstanceState = ProcessInstanceState.ACTIVATED

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Timer.kt
@@ -1,20 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.Enumerated
-import javax.persistence.EnumType
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 class Timer(
-    @Id val key: Long,
-    val position: Long,
-    val dueDate: Long,
-    var repetitions: Int,
-    val elementId: String,
-    var processInstanceKey: Long?,
-    val elementInstanceKey: Long?,
-    val processDefinitionKey: Long?
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val dueDate: Long,
+        var repetitions: Int,
+        val elementId: String,
+        var processInstanceKey: Long?,
+        val elementInstanceKey: Long?,
+        val processDefinitionKey: Long?
 ) {
 
     @Enumerated(EnumType.STRING)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/UserTask.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/UserTask.kt
@@ -1,13 +1,10 @@
 package io.zeebe.zeeqs.data.entity
 
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.Id
+import javax.persistence.*
 
 @Entity
 data class UserTask(
-        @Id val key: Long,
+        @Id @Column(name = "key_") val key: Long,
         val position: Long,
         val processInstanceKey: Long,
         val processDefinitionKey: Long,

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Variable.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/Variable.kt
@@ -1,16 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
 
 @Entity
 class Variable(
-    @Id val key: Long,
-    val position: Long,
-    val name: String,
-    val processInstanceKey: Long,
-    val scopeKey: Long,
-    @Lob var value: String,
-    var timestamp: Long
+        @Id @Column(name = "key_") val key: Long,
+        val position: Long,
+        val name: String,
+        val processInstanceKey: Long,
+        val scopeKey: Long,
+        @Lob @Column(name = "value_") var value: String,
+        var timestamp: Long
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableUpdate.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableUpdate.kt
@@ -1,16 +1,17 @@
 package io.zeebe.zeeqs.data.entity
 
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Lob
 
 @Entity
 class VariableUpdate(
-    @Id val partitionIdWithPosition: String,
-    val variableKey: Long,
-    val name: String,
-    @Lob val value: String,
-    val processInstanceKey: Long,
-    val scopeKey: Long,
-    val timestamp: Long
+        @Id val partitionIdWithPosition: String,
+        val variableKey: Long,
+        val name: String,
+        @Lob @Column(name = "value_") val value: String,
+        val processInstanceKey: Long,
+        val scopeKey: Long,
+        val timestamp: Long
 )

--- a/graphql-api/pom.xml
+++ b/graphql-api/pom.xml
@@ -1,56 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.zeebe.zeeqs</groupId>
-    <artifactId>zeeqs-root</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>io.zeebe.zeeqs</groupId>
+        <artifactId>zeeqs-root</artifactId>
+        <version>2.6.1-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>graphql-api</artifactId>
-  <name>ZeeQS - GraphQL API</name>
+    <artifactId>graphql-api</artifactId>
+    <name>ZeeQS - GraphQL API</name>
 
-  <dependencies>
+    <dependencies>
 
-    <dependency>
-      <groupId>io.zeebe.zeeqs</groupId>
-      <artifactId>data</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.zeebe.zeeqs</groupId>
+            <artifactId>data</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>com.graphql-java-kickstart</groupId>
-      <artifactId>graphql-spring-boot-starter</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-graphql</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>com.graphql-java-kickstart</groupId>
-      <artifactId>graphiql-spring-boot-starter</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.graphql</groupId>
+            <artifactId>spring-graphql-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>com.graphql-java-kickstart</groupId>
-      <artifactId>graphql-java-tools</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-  </dependencies>
+    </dependencies>
 
 </project>

--- a/graphql-api/pom.xml
+++ b/graphql-api/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.graphql</groupId>
             <artifactId>spring-graphql-test</artifactId>
             <scope>test</scope>

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ElementInstanceConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ElementInstanceConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class ElementInstanceConnectionResolver : GraphQLResolver<ElementInstanceConnection> {
+@Controller
+class ElementInstanceConnectionResolver {
 
+    @SchemaMapping(typeName = "ElementInstanceConnection", field = "nodes")
     fun nodes(connection: ElementInstanceConnection): List<ElementInstance> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "ElementInstanceConnection", field = "totalCount")
     fun totalCount(connection: ElementInstanceConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ErrorConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ErrorConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Error
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class ErrorConnectionResolver: GraphQLResolver<ErrorConnection> {
+@Controller
+class ErrorConnectionResolver {
 
+    @SchemaMapping(typeName = "ErrorConnection", field = "nodes")
     fun nodes(connection: ErrorConnection): List<Error> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "ErrorConnection", field = "totalCount")
     fun totalCount(connection: ErrorConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/IncidentConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/IncidentConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Incident
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class IncidentConnectionResolver : GraphQLResolver<IncidentConnection> {
+@Controller
+class IncidentConnectionResolver {
 
+    @SchemaMapping(typeName = "IncidentConnection", field = "nodes")
     fun nodes(connection: IncidentConnection): List<Incident> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "IncidentConnection", field = "totalCount")
     fun totalCount(connection: IncidentConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/JobConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/JobConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Job
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class JobConnectionResolver : GraphQLResolver<JobConnection> {
+@Controller
+class JobConnectionResolver {
 
+    @SchemaMapping(typeName = "JobConnection", field = "nodes")
     fun nodes(connection: JobConnection): List<Job> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "JobConnection", field = "totalCount")
     fun totalCount(connection: JobConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/MessageConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/MessageConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Message
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class MessageConnectionResolver : GraphQLResolver<MessageConnection> {
+@Controller
+class MessageConnectionResolver {
 
+    @SchemaMapping(typeName = "MessageConnection", field = "nodes")
     fun nodes(connection: MessageConnection): List<Message> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "MessageConnection", field = "totalCount")
     fun totalCount(connection: MessageConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ProcessConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ProcessConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Process
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class ProcessConnectionResolver : GraphQLResolver<ProcessConnection> {
+@Controller
+class ProcessConnectionResolver {
 
+    @SchemaMapping(typeName = "ProcessConnection", field = "nodes")
     fun nodes(connection: ProcessConnection): List<Process> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "ProcessConnection", field = "totalCount")
     fun totalCount(connection: ProcessConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ProcessInstanceConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/ProcessInstanceConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ProcessInstance
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class ProcessInstanceConnectionResolver : GraphQLResolver<ProcessInstanceConnection> {
+@Controller
+class ProcessInstanceConnectionResolver {
 
+    @SchemaMapping(typeName = "ProcessInstanceConnection", field = "nodes")
     fun nodes(connection: ProcessInstanceConnection): List<ProcessInstance> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "ProcessInstanceConnection", field = "totalCount")
     fun totalCount(connection: ProcessInstanceConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/UserTaskConnectionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/connection/UserTaskConnectionResolver.kt
@@ -1,16 +1,18 @@
 package io.zeebe.zeeqs.graphql.resolvers.connection
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.UserTask
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class UserTaskConnectionResolver: GraphQLResolver<UserTaskConnection> {
+@Controller
+class UserTaskConnectionResolver {
 
+    @SchemaMapping(typeName = "UserTaskConnection", field = "nodes")
     fun nodes(connection: UserTaskConnection): List<UserTask> {
         return connection.getItems()
     }
 
+    @SchemaMapping(typeName = "UserTaskConnection", field = "totalCount")
     fun totalCount(connection: UserTaskConnection): Long {
         return connection.getCount()
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ErrorQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ErrorQueryResolver.kt
@@ -1,19 +1,21 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.repository.ErrorRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.ErrorConnection
 import org.springframework.data.domain.PageRequest
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class ErrorQueryResolver(
         val errorRepository: ErrorRepository
-) : GraphQLQueryResolver {
+) {
 
+    @QueryMapping
     fun errors(
-            perPage: Int,
-            page: Int
+            @Argument perPage: Int,
+            @Argument page: Int
     ): ErrorConnection {
 
         return ErrorConnection(

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/IncidentQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/IncidentQueryResolver.kt
@@ -1,23 +1,25 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.Incident
 import io.zeebe.zeeqs.data.entity.IncidentState
 import io.zeebe.zeeqs.data.repository.IncidentRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.IncidentConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class IncidentQueryResolver(
         val incidentRepository: IncidentRepository
-) : GraphQLQueryResolver {
+) {
 
+    @QueryMapping
     fun incidents(
-            perPage: Int,
-            page: Int,
-            stateIn: List<IncidentState>
+            @Argument perPage: Int,
+            @Argument page: Int,
+            @Argument stateIn: List<IncidentState>
     ): IncidentConnection {
 
         return IncidentConnection(
@@ -31,7 +33,8 @@ class IncidentQueryResolver(
         )
     }
 
-    fun incident(key: Long): Incident? {
+    @QueryMapping
+    fun incident(@Argument key: Long): Incident? {
         return incidentRepository.findByIdOrNull(key)
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/JobQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/JobQueryResolver.kt
@@ -1,24 +1,26 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.Job
 import io.zeebe.zeeqs.data.entity.JobState
 import io.zeebe.zeeqs.data.repository.JobRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.JobConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class JobQueryResolver(
         val jobRepository: JobRepository
-) : GraphQLQueryResolver {
+) {
 
+    @QueryMapping
     fun jobs(
-            perPage: Int,
-            page: Int,
-            stateIn: List<JobState>,
-            jobTypeIn: List<String>): JobConnection {
+            @Argument perPage: Int,
+            @Argument page: Int,
+            @Argument stateIn: List<JobState>,
+            @Argument jobTypeIn: List<String>): JobConnection {
 
         if (jobTypeIn.isEmpty()) {
             return JobConnection(
@@ -43,7 +45,8 @@ class JobQueryResolver(
         }
     }
 
-    fun job(key: Long): Job? {
+    @QueryMapping
+    fun job(@Argument key: Long): Job? {
         return jobRepository.findByIdOrNull(key)
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/MessageQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/MessageQueryResolver.kt
@@ -1,20 +1,26 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.Message
 import io.zeebe.zeeqs.data.entity.MessageState
 import io.zeebe.zeeqs.data.repository.MessageRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.MessageConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class MessageQueryResolver(
         val messageRepository: MessageRepository
-) : GraphQLQueryResolver {
+) {
 
-    fun messages(perPage: Int, page: Int, stateIn: List<MessageState>): MessageConnection {
+    @QueryMapping
+    fun messages(
+            @Argument perPage: Int,
+            @Argument page: Int,
+            @Argument stateIn: List<MessageState>
+    ): MessageConnection {
         return MessageConnection(
                 getItems = {
                     messageRepository.findByStateIn(
@@ -30,7 +36,8 @@ class MessageQueryResolver(
         )
     }
 
-    fun message(key: Long): Message? {
+    @QueryMapping
+    fun message(@Argument key: Long): Message? {
         return messageRepository.findByIdOrNull(key)
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
@@ -1,27 +1,34 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstanceState
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class ProcessInstanceQueryResolver(
         val processInstanceRepository: ProcessInstanceRepository
-) : GraphQLQueryResolver {
+) {
 
-    fun processInstances(perPage: Int, page: Int, stateIn: List<ProcessInstanceState>): ProcessInstanceConnection {
+    @QueryMapping
+    fun processInstances(
+            @Argument perPage: Int,
+            @Argument page: Int,
+            @Argument stateIn: List<ProcessInstanceState>
+    ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
                 getItems = { processInstanceRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList() },
                 getCount = { processInstanceRepository.countByStateIn(stateIn) }
         )
     }
 
-    fun processInstance(key: Long): ProcessInstance? {
+    @QueryMapping
+    fun processInstance(@Argument key: Long): ProcessInstance? {
         return processInstanceRepository.findByIdOrNull(key)
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessQueryResolver.kt
@@ -1,26 +1,32 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.Process
 import io.zeebe.zeeqs.data.repository.ProcessRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class ProcessQueryResolver(
         val processRepository: ProcessRepository
-) : GraphQLQueryResolver {
+) {
 
-    fun processes(perPage: Int, page: Int): ProcessConnection {
+    @QueryMapping
+    fun processes(
+            @Argument perPage: Int,
+            @Argument page: Int
+    ): ProcessConnection {
         return ProcessConnection(
                 getItems = { processRepository.findAll(PageRequest.of(page, perPage)).toList() },
                 getCount = { processRepository.count() }
         )
     }
 
-    fun getProcess(key: Long): Process? {
+    @QueryMapping
+    fun process(@Argument key: Long): Process? {
         return processRepository.findByIdOrNull(key)
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/UserTaskQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/UserTaskQueryResolver.kt
@@ -1,23 +1,26 @@
 package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.UserTask
 import io.zeebe.zeeqs.data.entity.UserTaskState
 import io.zeebe.zeeqs.data.repository.UserTaskRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.UserTaskConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class UserTaskQueryResolver(
         val userTaskRepository: UserTaskRepository
-) : GraphQLQueryResolver {
+) {
 
+    @QueryMapping
     fun userTasks(
-            perPage: Int,
-            page: Int,
-            stateIn: List<UserTaskState>): UserTaskConnection {
+            @Argument perPage: Int,
+            @Argument page: Int,
+            @Argument stateIn: List<UserTaskState>
+    ): UserTaskConnection {
 
         return UserTaskConnection(
                 getItems = {
@@ -34,7 +37,8 @@ class UserTaskQueryResolver(
         )
     }
 
-    fun userTask(key: Long): UserTask? {
+    @QueryMapping
+    fun userTask(@Argument key: Long): UserTask? {
         return userTaskRepository.findByIdOrNull(key)
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/VariableQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/VariableQueryResolver.kt
@@ -1,16 +1,18 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.query
 
-import graphql.kickstart.tools.GraphQLQueryResolver
 import io.zeebe.zeeqs.data.entity.Variable
 import io.zeebe.zeeqs.data.repository.VariableRepository
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class VariableQueryResolver(
         val variableRepository: VariableRepository
-) : GraphQLQueryResolver {
+) {
 
-    fun getVariables(processInstanceKey: Long): List<Variable> {
+    @QueryMapping
+    fun getVariables(@Argument processInstanceKey: Long): List<Variable> {
         return variableRepository.findByProcessInstanceKey(processInstanceKey);
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceStateTransitionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ElementInstanceStateTransitionResolver.kt
@@ -1,14 +1,18 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstanceStateTransition
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class ElementInstanceStateTransitionResolver : GraphQLResolver<ElementInstanceStateTransition> {
+@Controller
+class ElementInstanceStateTransitionResolver {
 
-    fun timestamp(elementInstanceStateTransition: ElementInstanceStateTransition, zoneId: String): String? {
+    @SchemaMapping(typeName = "ElementInstanceStateTransition", field = "timestamp")
+    fun timestamp(
+            elementInstanceStateTransition: ElementInstanceStateTransition,
+            @Argument zoneId: String
+    ): String? {
         return elementInstanceStateTransition.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ErrorResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ErrorResolver.kt
@@ -1,17 +1,18 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Error
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class ErrorResolver(
         val processInstanceRepository: ProcessInstanceRepository
-) : GraphQLResolver<Error> {
+) {
 
+    @SchemaMapping(typeName = "Error", field = "processInstance")
     fun processInstance(error: Error): ProcessInstance? {
         return error.processInstanceKey?.let { processInstanceRepository.findByIdOrNull(it) }
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/IncidentResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/IncidentResolver.kt
@@ -1,6 +1,5 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
 import io.zeebe.zeeqs.data.entity.Incident
 import io.zeebe.zeeqs.data.entity.Job
@@ -8,33 +7,45 @@ import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.JobRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class IncidentResolver(
-    val processInstanceRepository: ProcessInstanceRepository,
-    val jobRepository: JobRepository,
-    val elementInstanceRepository: ElementInstanceRepository
-) : GraphQLResolver<Incident> {
+        val processInstanceRepository: ProcessInstanceRepository,
+        val jobRepository: JobRepository,
+        val elementInstanceRepository: ElementInstanceRepository
+) {
 
-    fun creationTime(incident: Incident, zoneId: String): String? {
+    @SchemaMapping(typeName = "Incident", field = "creationTime")
+    fun creationTime(
+            incident: Incident,
+            @Argument zoneId: String
+    ): String? {
         return incident.creationTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun resolveTime(incident: Incident, zoneId: String): String? {
+    @SchemaMapping(typeName = "Incident", field = "resolveTime")
+    fun resolveTime(
+            incident: Incident,
+            @Argument zoneId: String
+    ): String? {
         return incident.resolveTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "Incident", field = "processInstance")
     fun processInstance(incident: Incident): ProcessInstance? {
         return processInstanceRepository.findByIdOrNull(incident.processInstanceKey)
     }
 
+    @SchemaMapping(typeName = "Incident", field = "job")
     fun job(incident: Incident): Job? {
         return incident.jobKey?.let { jobRepository.findByIdOrNull(it) }
     }
 
+    @SchemaMapping(typeName = "Incident", field = "elementInstance")
     fun elementInstance(incident: Incident): ElementInstance? {
         return elementInstanceRepository.findByIdOrNull(incident.elementInstanceKey)
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/JobResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/JobResolver.kt
@@ -1,6 +1,5 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
 import io.zeebe.zeeqs.data.entity.Incident
 import io.zeebe.zeeqs.data.entity.Job
@@ -8,37 +7,53 @@ import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.IncidentRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class JobResolver(
-    val processInstanceRepository: ProcessInstanceRepository,
-    val incidentRepository: IncidentRepository,
-    val elementInstanceRepository: ElementInstanceRepository
-) : GraphQLResolver<Job> {
+        val processInstanceRepository: ProcessInstanceRepository,
+        val incidentRepository: IncidentRepository,
+        val elementInstanceRepository: ElementInstanceRepository
+) {
 
-    fun timestamp(job: Job, zoneId: String): String? {
+    @SchemaMapping(typeName = "Job", field = "timestamp")
+    fun timestamp(
+            job: Job,
+            @Argument zoneId: String
+    ): String? {
         return job.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun startTime(job: Job, zoneId: String): String? {
+    @SchemaMapping(typeName = "Job", field = "startTime")
+    fun startTime(
+            job: Job,
+            @Argument zoneId: String
+    ): String? {
         return job.startTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun endTime(job: Job, zoneId: String): String? {
+    @SchemaMapping(typeName = "Job", field = "endTime")
+    fun endTime(
+            job: Job,
+            @Argument zoneId: String
+    ): String? {
         return job.endTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "Job", field = "processInstance")
     fun processInstance(job: Job): ProcessInstance? {
         return processInstanceRepository.findByIdOrNull(job.processInstanceKey)
     }
 
+    @SchemaMapping(typeName = "Job", field = "incidents")
     fun incidents(job: Job): List<Incident> {
         return incidentRepository.findByJobKey(job.key)
     }
 
+    @SchemaMapping(typeName = "Job", field = "elementInstance")
     fun elementInstance(job: Job): ElementInstance? {
         return elementInstanceRepository.findByIdOrNull(job.elementInstanceKey)
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageCorrelationResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageCorrelationResolver.kt
@@ -1,6 +1,5 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Message
 import io.zeebe.zeeqs.data.entity.MessageCorrelation
 import io.zeebe.zeeqs.data.entity.MessageSubscription
@@ -8,41 +7,49 @@ import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.repository.MessageRepository
 import io.zeebe.zeeqs.data.repository.MessageSubscriptionRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class MessageCorrelationResolver(
-    val messageSubscriptionRepository: MessageSubscriptionRepository,
-    val messageRepository: MessageRepository,
-    val processInstanceRepository: ProcessInstanceRepository
-) : GraphQLResolver<MessageCorrelation> {
+        val messageSubscriptionRepository: MessageSubscriptionRepository,
+        val messageRepository: MessageRepository,
+        val processInstanceRepository: ProcessInstanceRepository
+) {
 
-    fun timestamp(messageCorrelation: MessageCorrelation, zoneId: String): String? {
+    @SchemaMapping(typeName = "MessageCorrelation", field = "timestamp")
+    fun timestamp(
+            messageCorrelation: MessageCorrelation,
+            @Argument zoneId: String
+    ): String? {
         return messageCorrelation.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "MessageCorrelation", field = "messageSubscription")
     fun messageSubscription(messageCorrelation: MessageCorrelation): MessageSubscription? {
         return messageCorrelation.elementInstanceKey
-            ?.let {
-                messageSubscriptionRepository.findByElementInstanceKeyAndMessageName(
-                    elementInstanceKey = it,
-                    messageName = messageCorrelation.messageName
-                )
-            }
-            ?: messageCorrelation.processDefinitionKey?.let {
-                messageSubscriptionRepository.findByProcessDefinitionKeyAndMessageName(
-                    processDefinitionKey = it,
-                    messageName = messageCorrelation.messageName
-                )
-            }
+                ?.let {
+                    messageSubscriptionRepository.findByElementInstanceKeyAndMessageName(
+                            elementInstanceKey = it,
+                            messageName = messageCorrelation.messageName
+                    )
+                }
+                ?: messageCorrelation.processDefinitionKey?.let {
+                    messageSubscriptionRepository.findByProcessDefinitionKeyAndMessageName(
+                            processDefinitionKey = it,
+                            messageName = messageCorrelation.messageName
+                    )
+                }
     }
 
+    @SchemaMapping(typeName = "MessageCorrelation", field = "message")
     fun message(messageCorrelation: MessageCorrelation): Message? {
         return messageRepository.findByIdOrNull(messageCorrelation.messageKey)
     }
 
+    @SchemaMapping(typeName = "MessageCorrelation", field = "processInstance")
     fun processInstance(messageCorrelation: MessageCorrelation): ProcessInstance? {
         return processInstanceRepository.findByIdOrNull(messageCorrelation.processInstanceKey)
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageResolver.kt
@@ -1,34 +1,40 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.Message
 import io.zeebe.zeeqs.data.entity.MessageCorrelation
-import io.zeebe.zeeqs.data.entity.MessageSubscription
 import io.zeebe.zeeqs.data.entity.MessageVariable
 import io.zeebe.zeeqs.data.repository.MessageCorrelationRepository
 import io.zeebe.zeeqs.data.repository.MessageVariableRepository
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 import java.time.Duration
 
-@Component
+@Controller
 class MessageResolver(
         val messageCorrelationRepository: MessageCorrelationRepository,
         val messageVariableRepository: MessageVariableRepository
-) : GraphQLResolver<Message> {
+) {
 
-    fun timestamp(message: Message, zoneId: String): String? {
+    @SchemaMapping(typeName = "Message", field = "timestamp")
+    fun timestamp(
+            message: Message,
+            @Argument zoneId: String
+    ): String? {
         return message.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "Message", field = "timeToLive")
     fun timeToLive(message: Message): String? {
         return message.timeToLive.let { Duration.ofMillis(it).toString() }
     }
 
+    @SchemaMapping(typeName = "Message", field = "messageCorrelations")
     fun messageCorrelations(message: Message): List<MessageCorrelation> {
         return messageCorrelationRepository.findByMessageKey(message.key)
     }
 
+    @SchemaMapping(typeName = "Message", field = "variables")
     fun variables(message: Message): List<MessageVariable> {
         return messageVariableRepository.findByMessageKey(messageKey = message.key)
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageSubscriptionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/MessageSubscriptionResolver.kt
@@ -1,36 +1,42 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.MessageCorrelationRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessRepository
-import io.zeebe.zeeqs.graphql.resolvers.type.BpmnElement
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class MessageSubscriptionResolver(
         val processInstanceRepository: ProcessInstanceRepository,
         val elementInstanceRepository: ElementInstanceRepository,
         val processRepository: ProcessRepository,
         val messageCorrelationRepository: MessageCorrelationRepository
-) : GraphQLResolver<MessageSubscription> {
+) {
 
-    fun timestamp(messageSubscription: MessageSubscription, zoneId: String): String? {
+    @SchemaMapping(typeName = "MessageSubscription", field = "timestamp")
+    fun timestamp(
+            messageSubscription: MessageSubscription,
+            @Argument zoneId: String
+    ): String? {
         return messageSubscription.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "MessageSubscription", field = "processInstance")
     fun processInstance(messageSubscription: MessageSubscription): ProcessInstance? {
         return messageSubscription.processInstanceKey?.let { processInstanceRepository.findByIdOrNull(it) }
     }
 
+    @SchemaMapping(typeName = "MessageSubscription", field = "elementInstance")
     fun elementInstance(messageSubscription: MessageSubscription): ElementInstance? {
         return messageSubscription.elementInstanceKey?.let { elementInstanceRepository.findByIdOrNull(it) }
     }
 
+    @SchemaMapping(typeName = "MessageSubscription", field = "process")
     fun process(messageSubscription: MessageSubscription): Process? {
         return messageSubscription.processDefinitionKey?.let { processRepository.findByIdOrNull(it) }
                 ?: messageSubscription.processInstanceKey?.let {
@@ -39,6 +45,7 @@ class MessageSubscriptionResolver(
                 }
     }
 
+    @SchemaMapping(typeName = "MessageSubscription", field = "messageCorrelations")
     fun messageCorrelations(messageSubscription: MessageSubscription): List<MessageCorrelation> {
         return messageSubscription.elementInstanceKey
                 ?.let {
@@ -55,6 +62,7 @@ class MessageSubscriptionResolver(
                 ?: emptyList()
     }
 
+    @SchemaMapping(typeName = "MessageSubscription", field = "element")
     fun element(messageSubscription: MessageSubscription): BpmnElement? {
         val processDefinitionKeyOfSubscription = messageSubscription.processDefinitionKey
                 ?: processInstanceRepository

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/TimerResolver.kt
@@ -1,47 +1,64 @@
 package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
-import io.zeebe.zeeqs.data.entity.Timer
 import io.zeebe.zeeqs.data.entity.Process
 import io.zeebe.zeeqs.data.entity.ProcessInstance
+import io.zeebe.zeeqs.data.entity.Timer
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessRepository
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class TimerResolver(
-    val processRepository: ProcessRepository,
-    val processInstanceRepository: ProcessInstanceRepository,
-    val elementInstanceRepository: ElementInstanceRepository
-) : GraphQLResolver<Timer> {
+        val processRepository: ProcessRepository,
+        val processInstanceRepository: ProcessInstanceRepository,
+        val elementInstanceRepository: ElementInstanceRepository
+) {
 
-    fun startTime(timer: Timer, zoneId: String): String? {
+    @SchemaMapping(typeName = "Timer", field = "startTime")
+    fun startTime(
+            timer: Timer,
+            @Argument zoneId: String
+    ): String? {
         return timer.startTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun endTime(timer: Timer, zoneId: String): String? {
+    @SchemaMapping(typeName = "Timer", field = "endTime")
+    fun endTime(
+            timer: Timer,
+            @Argument zoneId: String
+    ): String? {
         return timer.endTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun dueDate(timer: Timer, zoneId: String): String? {
+    @SchemaMapping(typeName = "Timer", field = "dueDate")
+    fun dueDate(
+            timer: Timer,
+            @Argument zoneId: String
+    ): String? {
         return timer.dueDate.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "Timer", field = "process")
     fun process(timer: Timer): Process? {
         return timer.processDefinitionKey?.let { processRepository.findByIdOrNull(it) }
     }
 
+    @SchemaMapping(typeName = "Timer", field = "processInstance")
     fun processInstance(timer: Timer): ProcessInstance? {
         return timer.processInstanceKey?.let { processInstanceRepository.findByIdOrNull(it) }
     }
 
+    @SchemaMapping(typeName = "Timer", field = "elementInstance")
     fun elementInstance(timer: Timer): ElementInstance? {
         return timer.elementInstanceKey?.let { elementInstanceRepository.findByIdOrNull(it) }
     }
 
+    @SchemaMapping(typeName = "Timer", field = "element")
     fun element(timer: Timer): BpmnElement? {
         return timer.processDefinitionKey?.let {
             BpmnElement(

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/UserTaskResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/UserTaskResolver.kt
@@ -1,43 +1,59 @@
 package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.UserTask
-import io.zeebe.zeeqs.data.service.UserTaskForm
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.service.ProcessService
+import io.zeebe.zeeqs.data.service.UserTaskForm
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class UserTaskResolver(
         val processInstanceRepository: ProcessInstanceRepository,
         val elementInstanceRepository: ElementInstanceRepository,
         val processService: ProcessService
-) : GraphQLResolver<UserTask> {
+) {
 
-    fun timestamp(userTask: UserTask, zoneId: String): String? {
+    @SchemaMapping(typeName = "UserTask", field = "timestamp")
+    fun timestamp(
+            userTask: UserTask,
+            @Argument zoneId: String
+    ): String? {
         return userTask.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun startTime(userTask: UserTask, zoneId: String): String? {
+    @SchemaMapping(typeName = "UserTask", field = "startTime")
+    fun startTime(
+            userTask: UserTask,
+            @Argument zoneId: String
+    ): String? {
         return userTask.startTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
-    fun endTime(userTask: UserTask, zoneId: String): String? {
+    @SchemaMapping(typeName = "UserTask", field = "endTime")
+    fun endTime(
+            userTask: UserTask,
+            @Argument zoneId: String
+    ): String? {
         return userTask.endTime?.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "UserTask", field = "processInstance")
     fun processInstance(userTask: UserTask): ProcessInstance? {
         return processInstanceRepository.findByIdOrNull(userTask.processInstanceKey)
     }
 
+    @SchemaMapping(typeName = "UserTask", field = "elementInstance")
     fun elementInstance(userTask: UserTask): ElementInstance? {
         return elementInstanceRepository.findByIdOrNull(userTask.elementInstanceKey)
     }
 
+    @SchemaMapping(typeName = "UserTask", field = "form")
     fun form(userTask: UserTask): UserTaskForm? {
         return userTask.formKey?.let { formKey ->
             UserTaskForm(

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableResolver.kt
@@ -1,29 +1,35 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.ElementInstance
 import io.zeebe.zeeqs.data.entity.Variable
 import io.zeebe.zeeqs.data.entity.VariableUpdate
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.VariableUpdateRepository
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
+@Controller
 class VariableResolver(
         val variableUpdateRepository: VariableUpdateRepository,
         val elementInstanceRepository: ElementInstanceRepository
-) : GraphQLResolver<Variable> {
+) {
 
-    fun timestamp(variable: Variable, zoneId: String): String? {
+    @SchemaMapping(typeName = "Variable", field = "timestamp")
+    fun timestamp(
+            variable: Variable,
+            @Argument zoneId: String
+    ): String? {
         return variable.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 
+    @SchemaMapping(typeName = "Variable", field = "updates")
     fun updates(variable: Variable): List<VariableUpdate> {
         return variableUpdateRepository.findByVariableKey(variable.key)
     }
 
+    @SchemaMapping(typeName = "Variable", field = "scope")
     fun scope(variable: Variable): ElementInstance? {
         return elementInstanceRepository.findByIdOrNull(variable.scopeKey)
     }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableUpdateResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/VariableUpdateResolver.kt
@@ -1,14 +1,18 @@
-package io.zeebe.zeeqs.data.resolvers
+package io.zeebe.zeeqs.graphql.resolvers.type
 
-import graphql.kickstart.tools.GraphQLResolver
 import io.zeebe.zeeqs.data.entity.VariableUpdate
-import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension
-import org.springframework.stereotype.Component
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+import org.springframework.stereotype.Controller
 
-@Component
-class VariableUpdateResolver : GraphQLResolver<VariableUpdate> {
+@Controller
+class VariableUpdateResolver {
 
-    fun timestamp(variableUpdate: VariableUpdate, zoneId: String): String? {
+    @SchemaMapping(typeName = "VariableUpdate", field = "timestamp")
+    fun timestamp(
+            variableUpdate: VariableUpdate,
+            @Argument zoneId: String
+    ): String? {
         return variableUpdate.timestamp.let { ResolverExtension.timestampToString(it, zoneId) }
     }
 

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/GraphqlAssertions.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/GraphqlAssertions.kt
@@ -1,31 +1,33 @@
 package io.zeebe.zeeqs
 
 import org.assertj.core.api.Assertions
-import org.springframework.boot.web.server.LocalServerPort
-import org.springframework.stereotype.Component
 import java.net.URI
-import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
-import java.nio.charset.StandardCharsets
 
 class GraphqlAssertions(private val port: Int) {
 
     fun assertQuery(query: String, expectedResponseBody: String) {
         val response = sendQuery(query)
 
-        Assertions.assertThat(response.statusCode()).isEqualTo(200)
+        Assertions.assertThat(response.statusCode())
+                .describedAs(
+                        "Expect the request to be successful but the status code was '%s'.",
+                        response.statusCode(),
+                        response.toString())
+                .isEqualTo(200)
         Assertions.assertThat(response.body()).isEqualToIgnoringWhitespace(expectedResponseBody)
     }
 
     private fun sendQuery(query: String): HttpResponse<String> {
-        val encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8)
-        val uri = "http://localhost:$port/graphql?query=$encodedQuery"
+        val encodedQuery = query.replace("\n", "")
+        val uri = "http://localhost:$port/graphql"
 
         val request = HttpRequest.newBuilder()
                 .uri(URI(uri))
-                .GET()
+                .POST(HttpRequest.BodyPublishers.ofString("""{"query": "$encodedQuery"}"""))
+                .header("Content-Type", "application/json")
                 .build()
 
         return HttpClient

--- a/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlProcessTest.kt
+++ b/graphql-api/src/test/kotlin/io/zeebe/zeeqs/ZeebeGraphqlProcessTest.kt
@@ -2,9 +2,7 @@ package io.zeebe.zeeqs
 
 import io.camunda.zeebe.model.bpmn.Bpmn
 import io.zeebe.zeeqs.data.entity.Process
-import io.zeebe.zeeqs.data.entity.UserTask
 import io.zeebe.zeeqs.data.repository.ProcessRepository
-import io.zeebe.zeeqs.data.repository.UserTaskRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/pom.xml
+++ b/pom.xml
@@ -1,386 +1,379 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <packaging>pom</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
 
-  <parent>
-    <groupId>org.camunda</groupId>
-    <artifactId>camunda-release-parent</artifactId>
-    <version>3.9.1</version>
-    <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
-  </parent>
+    <parent>
+        <groupId>org.camunda</groupId>
+        <artifactId>camunda-release-parent</artifactId>
+        <version>3.9.1</version>
+        <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
+        <relativePath/>
+    </parent>
 
-  <groupId>io.zeebe.zeeqs</groupId>
-  <artifactId>zeeqs-root</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
-  <name>ZeeQS - Root</name>
-  <description>Query API for aggregated Zeebe data</description>
+    <groupId>io.zeebe.zeeqs</groupId>
+    <artifactId>zeeqs-root</artifactId>
+    <version>2.6.1-SNAPSHOT</version>
+    <name>ZeeQS - Root</name>
+    <description>Query API for aggregated Zeebe data</description>
 
-  <modules>
-    <module>data</module>
-    <module>graphql-api</module>
-    <module>hazelcast-importer</module>
-    <module>app</module>
-  </modules>
+    <modules>
+        <module>data</module>
+        <module>graphql-api</module>
+        <module>hazelcast-importer</module>
+        <module>app</module>
+    </modules>
 
-  <properties>
-    <kotlin.version>1.8.0</kotlin.version>
+    <properties>
+        <kotlin.version>1.8.0</kotlin.version>
 
-    <zeebe.version>8.1.6</zeebe.version>
+        <zeebe.version>8.1.6</zeebe.version>
 
-    <spring.boot.version>2.6.7</spring.boot.version>
+        <spring.boot.version>2.6.7</spring.boot.version>
 
-    <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
-    <!-- pin Hazelcast version because of spring-boot-dependencies -->
-    <version.hazelcast>5.2.1</version.hazelcast>
+        <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
+        <!-- pin Hazelcast version because of spring-boot-dependencies -->
+        <version.hazelcast>5.2.1</version.hazelcast>
 
-    <version.graphql>8.1.1</version.graphql>
-    <version.graphql.tools>6.3.0</version.graphql.tools>
+        <zeebe-test-container.version>3.5.2</zeebe-test-container.version>
+        <test-container.version>1.17.6</test-container.version>
 
-    <zeebe-test-container.version>3.5.2</zeebe-test-container.version>
-    <test-container.version>1.17.6</test-container.version>
+        <!-- release parent settings -->
+        <version.java>11</version.java>
+        <nexus.snapshot.repository>
+            https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
+        </nexus.snapshot.repository>
+        <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
+        </nexus.release.repository>
 
-    <!-- release parent settings -->
-    <version.java>11</version.java>
-    <nexus.snapshot.repository>
-      https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
-    </nexus.snapshot.repository>
-    <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
-    </nexus.release.repository>
+        <!-- disable jdk8 javadoc checks on release build -->
+        <additionalparam>-Xdoclint:none</additionalparam>
 
-    <!-- disable jdk8 javadoc checks on release build -->
-    <additionalparam>-Xdoclint:none</additionalparam>
+        <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
+    </properties>
 
-    <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-
-      <dependency>
-        <groupId>io.zeebe.zeeqs</groupId>
-        <artifactId>data</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe.zeeqs</groupId>
-        <artifactId>graphql-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe.zeeqs</groupId>
-        <artifactId>hazelcast-importer</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-bom</artifactId>
-        <version>${zeebe.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe.hazelcast</groupId>
-        <artifactId>zeebe-hazelcast-connector</artifactId>
-        <version>${hazelcast.exporter.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast</artifactId>
-        <version>${version.hazelcast}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.graphql-java-kickstart</groupId>
-        <artifactId>graphql-spring-boot-starter</artifactId>
-        <version>${version.graphql}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.graphql-java-kickstart</groupId>
-        <artifactId>graphiql-spring-boot-starter</artifactId>
-        <version>${version.graphql}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.graphql-java-kickstart</groupId>
-        <artifactId>graphql-java-tools</artifactId>
-        <version>${version.graphql.tools}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.zeebe</groupId>
-        <artifactId>zeebe-test-container</artifactId>
-        <version>${zeebe-test-container.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${test-container.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${test-container.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility-kotlin</artifactId>
-        <version>4.2.0</version>
-      </dependency>
-
-      <!-- Kotlin deps -->
-
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-common</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-reflect</artifactId>
-        <version>${kotlin.version}</version>
-      </dependency>
-
-    </dependencies>
-  </dependencyManagement>
-
-  <!-- common dependencies -->
-  <dependencies>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-reflect</artifactId>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
-
-    <plugins>
-
-      <plugin>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-maven-plugin</artifactId>
-        <version>${kotlin.version}</version>
-        <configuration>
-          <args>
-            <arg>-Xjsr305=strict</arg>
-          </args>
-          <compilerPlugins>
-            <plugin>spring</plugin>
-            <plugin>jpa</plugin>
-          </compilerPlugins>
-          <jvmTarget>11</jvmTarget>
-        </configuration>
+    <dependencyManagement>
         <dependencies>
-          <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-maven-allopen</artifactId>
-            <version>${kotlin.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-maven-noarg</artifactId>
-            <version>${kotlin.version}</version>
-          </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.zeeqs</groupId>
+                <artifactId>data</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.zeeqs</groupId>
+                <artifactId>graphql-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.zeeqs</groupId>
+                <artifactId>hazelcast-importer</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.camunda</groupId>
+                <artifactId>zeebe-bom</artifactId>
+                <version>${zeebe.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-graphql</artifactId>
+                <version>2.7.7</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.graphql</groupId>
+                <artifactId>spring-graphql-test</artifactId>
+                <scope>test</scope>
+                <version>1.1.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe.hazelcast</groupId>
+                <artifactId>zeebe-hazelcast-connector</artifactId>
+                <version>${hazelcast.exporter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.hazelcast</groupId>
+                <artifactId>hazelcast</artifactId>
+                <version>${version.hazelcast}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.zeebe</groupId>
+                <artifactId>zeebe-test-container</artifactId>
+                <version>${zeebe-test-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${test-container.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${test-container.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility-kotlin</artifactId>
+                <version>4.2.0</version>
+            </dependency>
+
+            <!-- Kotlin deps -->
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+
         </dependencies>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
+    </dependencyManagement>
 
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>test-compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+    <!-- common dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+    </dependencies>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
-      </plugin>
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
-        <configuration>
-          <release>11</release>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!-- Override java source version to workaround javadoc bug https://bugs.openjdk.java.net/browse/JDK-8212233 -->
-          <source>8</source>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.5.0</version>
-        <executions>
-          <execution>
-            <id>copy</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <artifactItems>
-            <artifactItem>
-              <groupId>io.zeebe.hazelcast</groupId>
-              <artifactId>zeebe-hazelcast-exporter</artifactId>
-              <version>${hazelcast.exporter.version}</version>
-              <type>jar</type>
-              <classifier>jar-with-dependencies</classifier>
-              <overWrite>true</overWrite>
-              <outputDirectory>${project.build.directory}/exporter</outputDirectory>
-              <destFileName>zeebe-hazelcast-exporter.jar</destFileName>
-            </artifactItem>
-          </artifactItems>
-          <outputDirectory>${project.build.directory}/libs</outputDirectory>
-          <overWriteReleases>false</overWriteReleases>
-          <overWriteSnapshots>true</overWriteSnapshots>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>empty-javadoc-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${basedir}/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-    </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <version>${jib-maven-plugin.version}</version>
-          <configuration>
-            <to>
-              <image>ghcr.io/camunda-community-hub/zeeqs</image>
-              <tags>${project.version}</tags>
-            </to>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>community-action-maven-release</id>
-      <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <!-- Prevent gpg from using pinentry programs -->
-              <gpgArguments>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-          </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <configuration>
+                    <args>
+                        <arg>-Xjsr305=strict</arg>
+                    </args>
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                        <plugin>jpa</plugin>
+                    </compilerPlugins>
+                    <jvmTarget>11</jvmTarget>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-noarg</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- Override java source version to workaround javadoc bug https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                    <source>8</source>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactItems>
+                        <artifactItem>
+                            <groupId>io.zeebe.hazelcast</groupId>
+                            <artifactId>zeebe-hazelcast-exporter</artifactId>
+                            <version>${hazelcast.exporter.version}</version>
+                            <type>jar</type>
+                            <classifier>jar-with-dependencies</classifier>
+                            <overWrite>true</overWrite>
+                            <outputDirectory>${project.build.directory}/exporter</outputDirectory>
+                            <destFileName>zeebe-hazelcast-exporter.jar</destFileName>
+                        </artifactItem>
+                    </artifactItems>
+                    <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                    <overWriteReleases>false</overWriteReleases>
+                    <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${basedir}/javadoc</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
-      </build>
-    </profile>
-  </profiles>
 
-  <repositories>
-    <repository>
-      <id>zeebe</id>
-      <name>Zeebe Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>${jib-maven-plugin.version}</version>
+                    <configuration>
+                        <to>
+                            <image>ghcr.io/camunda-community-hub/zeeqs</image>
+                            <tags>${project.version}</tags>
+                        </to>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
-    <repository>
-      <id>zeebe-snapshots</id>
-      <name>Zeebe Snapshot Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+    <profiles>
+        <profile>
+            <id>community-action-maven-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
-  <scm>
-    <url>https://github.com/camunda-community-hub/zeeqs</url>
-    <connection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</connection>
-    <developerConnection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+    <repositories>
+        <repository>
+            <id>zeebe</id>
+            <name>Zeebe Repository</name>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>zeebe-snapshots</id>
+            <name>Zeebe Snapshot Repository</name>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <scm>
+        <url>https://github.com/camunda-community-hub/zeeqs</url>
+        <connection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</connection>
+        <developerConnection>scm:git:git@github.com:camunda-community-hub/zeeqs.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <zeebe.version>8.1.6</zeebe.version>
 
-        <spring.boot.version>2.6.7</spring.boot.version>
+        <spring.boot.version>2.7.8</spring.boot.version>
 
         <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
         <!-- pin Hazelcast version because of spring-boot-dependencies -->
@@ -40,7 +40,7 @@
         <test-container.version>1.17.6</test-container.version>
 
         <!-- release parent settings -->
-        <version.java>11</version.java>
+        <version.java>17</version.java>
         <nexus.snapshot.repository>
             https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
         </nexus.snapshot.repository>
@@ -93,14 +93,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-graphql</artifactId>
-                <version>2.7.7</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.graphql</groupId>
-                <artifactId>spring-graphql-test</artifactId>
-                <scope>test</scope>
-                <version>1.1.1</version>
+                <version>${spring.boot.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

Replace previous GraphQL dependencies (`com.graphql-java-kickstart`) with the [Spring GraphQL integration](https://spring.io/projects/spring-graphql).

Migrate the GraphQL API:
- Annotate all resolvers with `@controller`.
- Annotate all query resolver methods with `@QueryMapping`.
- Annotate all field resolver methods with `@Schemamapping`. The `@SchemaMethod` on the class doesn't work. And, the annotation on the methods without arguments doesn't work too. Maybe, it's because of some issues with Kotlin.

Dump Spring version from `2.6.7` to `2.7.8`. The version update is required because the Spring GraphQL requires a version >= `2.7.x`. 

The new version of H2 (caused by the new version of Spring) doesn't work with the existing database schema because the columns `key` and `value` are reserved keywords. We need to change the column names to be compatible and update it to the new H2 version.

Dump the Java version from `11` to `17`. The new Java version will be required for new Spring versions >= `3.x`.

---

closes #134