### PR TITLE
deps: dump zeebe-hazelcast-exporter from 1.2.1 to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
@@ -7,7 +8,7 @@
         <groupId>org.camunda.community</groupId>
         <artifactId>community-hub-release-parent</artifactId>
         <version>1.4.1</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <groupId>io.zeebe.zeeqs</groupId>
@@ -30,7 +31,7 @@
 
         <spring.boot.version>2.7.9</spring.boot.version>
 
-        <hazelcast.exporter.version>1.2.1</hazelcast.exporter.version>
+        <hazelcast.exporter.version>1.3.0</hazelcast.exporter.version>
         <!-- pin Hazelcast version because of spring-boot-dependencies -->
         <version.hazelcast>5.2.2</version.hazelcast>
 


### PR DESCRIPTION
## Description

Dump `zeebe-hazelcast-exporter` from `1.2.1` to [1.3.0](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter/releases/tag/1.3.0).