### PR TITLE
feat: Fetch decision evaluations by process instance

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
@@ -13,5 +13,9 @@ interface DecisionEvaluationRepository : PagingAndSortingRepository<DecisionEval
 
     fun findAllByProcessInstanceKey(processInstanceKey: Long): List<DecisionEvaluation>
 
+    fun countByProcessInstanceKey(processInstanceKey: Long): Long
+
     fun findAllByElementInstanceKey(elementInstanceKey: Long): List<DecisionEvaluation>
+
+    fun countByElementInstanceKey(elementInstanceKey: Long): Long
 }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
@@ -2,6 +2,7 @@ package io.zeebe.zeeqs.graphql.resolvers.type
 
 import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
+import io.zeebe.zeeqs.graphql.resolvers.connection.DecisionEvaluationConnection
 import io.zeebe.zeeqs.graphql.resolvers.connection.UserTaskConnection
 import io.zeebe.zeeqs.graphql.resolvers.type.ResolverExtension.timestampToString
 import org.springframework.data.domain.PageRequest
@@ -12,38 +13,39 @@ import org.springframework.stereotype.Controller
 
 @Controller
 class ProcessInstanceResolver(
-        val processInstanceRepository: ProcessInstanceRepository,
-        val variableRepository: VariableRepository,
-        val processRepository: ProcessRepository,
-        val jobRepository: JobRepository,
-        val userTaskRepository: UserTaskRepository,
-        val incidentRepository: IncidentRepository,
-        val elementInstanceRepository: ElementInstanceRepository,
-        val timerRepository: TimerRepository,
-        val messageSubscriptionRepository: MessageSubscriptionRepository,
-        val errorRepository: ErrorRepository
+    val processInstanceRepository: ProcessInstanceRepository,
+    val variableRepository: VariableRepository,
+    val processRepository: ProcessRepository,
+    val jobRepository: JobRepository,
+    val userTaskRepository: UserTaskRepository,
+    val incidentRepository: IncidentRepository,
+    val elementInstanceRepository: ElementInstanceRepository,
+    val timerRepository: TimerRepository,
+    val messageSubscriptionRepository: MessageSubscriptionRepository,
+    val errorRepository: ErrorRepository,
+    private val decisionEvaluationRepository: DecisionEvaluationRepository
 ) {
 
     @SchemaMapping(typeName = "ProcessInstance", field = "startTime")
     fun startTime(
-            processInstance: ProcessInstance,
-            @Argument zoneId: String
+        processInstance: ProcessInstance,
+        @Argument zoneId: String
     ): String? {
         return processInstance.startTime?.let { timestampToString(it, zoneId) }
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "endTime")
     fun endTime(
-            processInstance: ProcessInstance,
-            @Argument zoneId: String
+        processInstance: ProcessInstance,
+        @Argument zoneId: String
     ): String? {
         return processInstance.endTime?.let { timestampToString(it, zoneId) }
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "variables")
     fun variables(
-            processInstance: ProcessInstance,
-            @Argument globalOnly: Boolean
+        processInstance: ProcessInstance,
+        @Argument globalOnly: Boolean
     ): List<Variable> {
         return if (globalOnly) {
             variableRepository.findByScopeKey(scopeKey = processInstance.key)
@@ -54,40 +56,42 @@ class ProcessInstanceResolver(
 
     @SchemaMapping(typeName = "ProcessInstance", field = "jobs")
     fun jobs(
-            processInstance: ProcessInstance,
-            @Argument stateIn: List<JobState>,
-            @Argument jobTypeIn: List<String>
+        processInstance: ProcessInstance,
+        @Argument stateIn: List<JobState>,
+        @Argument jobTypeIn: List<String>
     ): List<Job> {
         return if (jobTypeIn.isEmpty()) {
             jobRepository.findByProcessInstanceKeyAndStateIn(processInstance.key, stateIn)
         } else {
             jobRepository.findByProcessInstanceKeyAndStateInAndJobTypeIn(
-                    processInstanceKey = processInstance.key,
-                    stateIn = stateIn,
-                    jobTypeIn = jobTypeIn
+                processInstanceKey = processInstance.key,
+                stateIn = stateIn,
+                jobTypeIn = jobTypeIn
             )
         }
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "userTasks")
     fun userTasks(
-            processInstance: ProcessInstance,
-            @Argument perPage: Int,
-            @Argument page: Int,
-            @Argument stateIn: List<UserTaskState>): UserTaskConnection {
+        processInstance: ProcessInstance,
+        @Argument perPage: Int,
+        @Argument page: Int,
+        @Argument stateIn: List<UserTaskState>
+    ): UserTaskConnection {
         return UserTaskConnection(
-                getItems = {
-                    userTaskRepository.findByProcessInstanceKeyAndStateIn(
-                            processInstanceKey = processInstance.key,
-                            stateIn = stateIn,
-                            pageable = PageRequest.of(page, perPage))
-                },
-                getCount = {
-                    userTaskRepository.countByProcessInstanceKeyAndStateIn(
-                            processInstanceKey = processInstance.key,
-                            stateIn = stateIn
-                    )
-                }
+            getItems = {
+                userTaskRepository.findByProcessInstanceKeyAndStateIn(
+                    processInstanceKey = processInstance.key,
+                    stateIn = stateIn,
+                    pageable = PageRequest.of(page, perPage)
+                )
+            },
+            getCount = {
+                userTaskRepository.countByProcessInstanceKeyAndStateIn(
+                    processInstanceKey = processInstance.key,
+                    stateIn = stateIn
+                )
+            }
         )
     }
 
@@ -98,18 +102,22 @@ class ProcessInstanceResolver(
 
     @SchemaMapping(typeName = "ProcessInstance", field = "incidents")
     fun incidents(
-            processInstance: ProcessInstance,
-            @Argument stateIn: List<IncidentState>
+        processInstance: ProcessInstance,
+        @Argument stateIn: List<IncidentState>
     ): List<Incident> {
         return incidentRepository.findByProcessInstanceKeyAndStateIn(
-                processInstanceKey = processInstance.key,
-                stateIn = stateIn
+            processInstanceKey = processInstance.key,
+            stateIn = stateIn
         )
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "parentElementInstance")
     fun parentElementInstance(processInstance: ProcessInstance): ElementInstance? {
-        return processInstance.parentElementInstanceKey?.let { elementInstanceRepository.findByIdOrNull(it) }
+        return processInstance.parentElementInstanceKey?.let {
+            elementInstanceRepository.findByIdOrNull(
+                it
+            )
+        }
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "childProcessInstances")
@@ -119,12 +127,12 @@ class ProcessInstanceResolver(
 
     @SchemaMapping(typeName = "ProcessInstance", field = "elementInstances")
     fun elementInstances(
-            processInstance: ProcessInstance,
-            @Argument stateIn: List<ElementInstanceState>
+        processInstance: ProcessInstance,
+        @Argument stateIn: List<ElementInstanceState>
     ): List<ElementInstance> {
         return elementInstanceRepository.findByProcessInstanceKeyAndStateIn(
-                processInstanceKey = processInstance.key,
-                stateIn = stateIn
+            processInstanceKey = processInstance.key,
+            stateIn = stateIn
         )
     }
 
@@ -143,4 +151,11 @@ class ProcessInstanceResolver(
         return errorRepository.findByProcessInstanceKey(processInstance.key)
     }
 
+    @SchemaMapping(typeName = "ProcessInstance", field = "decisionEvaluations")
+    fun decisionEvaluations(processInstance: ProcessInstance): DecisionEvaluationConnection {
+        return DecisionEvaluationConnection(
+            getItems = { decisionEvaluationRepository.findAllByProcessInstanceKey(processInstanceKey = processInstance.key) },
+            getCount = { decisionEvaluationRepository.countByProcessInstanceKey(processInstanceKey = processInstance.key) }
+        )
+    }
 }

--- a/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ElementInstance.graphqls
@@ -38,6 +38,9 @@ type ElementInstance {
         # If false, it returns all variables, including variables with the same name.
         shadowing: Boolean = true
     ): [Variable!]!
+
+    # The evaluated decisions that are called by this element instance if the element is a business rule task.
+    decisionEvaluations: DecisionEvaluationConnection
 }
 
 type ElementInstanceStateTransition {

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -44,6 +44,8 @@ type ProcessInstance {
     timers: [Timer!]
     # the opened message subscriptions related to the process instance (e.g. message catch events)
     messageSubscriptions: [MessageSubscription!]
+    # The evaluated decisions that are called by a business rule task of this process instance.
+    decisionEvaluations: DecisionEvaluationConnection
     # the occurred error related to the process instance
     error: Error
 }


### PR DESCRIPTION
## Description

Add a connection in the GraphQL API from process instance and element instance to decision evaluations.

Related to https://github.com/camunda-community-hub/zeeqs/issues/286