### PR TITLE
feat: Get the evaluation time of the decision

### DIFF
--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/DecisionEvaluationResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/DecisionEvaluationResolver.kt
@@ -3,6 +3,7 @@ package io.zeebe.zeeqs.graphql.resolvers.type
 import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.repository.*
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.stereotype.Controller
 import kotlin.jvm.optionals.getOrNull
@@ -43,6 +44,19 @@ class DecisionEvaluationResolver(
     fun elementInstance(decisionEvaluation: DecisionEvaluation): ElementInstance? {
         return decisionEvaluation.elementInstanceKey?.let {
             elementInstanceRepository.findByIdOrNull(it)
+        }
+    }
+
+    @SchemaMapping(typeName = "DecisionEvaluation", field = "evaluationTime")
+    fun evaluationTime(
+        decisionEvaluation: DecisionEvaluation,
+        @Argument zoneId: String
+    ): String? {
+        return decisionEvaluation.evaluationTime.let {
+            ResolverExtension.timestampToString(
+                it,
+                zoneId
+            )
         }
     }
 

--- a/graphql-api/src/main/resources/graphql/DecisionEvaluation.graphqls
+++ b/graphql-api/src/main/resources/graphql/DecisionEvaluation.graphqls
@@ -8,6 +8,8 @@ type DecisionEvaluation {
     decisionOutput: String!
     # The state of the evaluation (i.e. evaluation was successful or with failures).
     state: DecisionEvaluationState!
+    # The time when the decision was evaluated.
+    evaluationTime(zoneId: String = "Z"): String!
     # All evaluated decisions (i.e. the root decision and all required decisions).
     evaluatedDecisions: [EvaluatedDecision!]
     # The failure message if the evaluation was not successful.


### PR DESCRIPTION
## Description

Add a field in the GraphQL API for decision evaluations to retrieve the time of the evaluation.

Related to https://github.com/camunda-community-hub/zeeqs/issues/286