### PR TITLE
feat: Query for decision evaluations

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
@@ -1,6 +1,8 @@
 package io.zeebe.zeeqs.data.repository
 
 import io.zeebe.zeeqs.data.entity.DecisionEvaluation
+import io.zeebe.zeeqs.data.entity.DecisionEvaluationState
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 
@@ -18,4 +20,11 @@ interface DecisionEvaluationRepository : PagingAndSortingRepository<DecisionEval
     fun findAllByElementInstanceKey(elementInstanceKey: Long): List<DecisionEvaluation>
 
     fun countByElementInstanceKey(elementInstanceKey: Long): Long
+
+    fun findByStateIn(
+        stateIn: List<DecisionEvaluationState>,
+        pageable: Pageable
+    ): List<DecisionEvaluation>
+
+    fun countByStateIn(stateIn: List<DecisionEvaluationState>): Long
 }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/DecisionEvaluationQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/DecisionEvaluationQueryResolver.kt
@@ -1,0 +1,40 @@
+package io.zeebe.zeeqs.graphql.resolvers.query
+
+import io.zeebe.zeeqs.data.entity.DecisionEvaluation
+import io.zeebe.zeeqs.data.entity.DecisionEvaluationState
+import io.zeebe.zeeqs.data.repository.DecisionEvaluationRepository
+import io.zeebe.zeeqs.graphql.resolvers.connection.DecisionEvaluationConnection
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.stereotype.Controller
+
+@Controller
+class DecisionEvaluationQueryResolver(
+    private val decisionEvaluationRepository: DecisionEvaluationRepository
+) {
+
+    @QueryMapping
+    fun decisionEvaluations(
+        @Argument perPage: Int,
+        @Argument page: Int,
+        @Argument stateIn: List<DecisionEvaluationState>
+    ): DecisionEvaluationConnection {
+        return DecisionEvaluationConnection(
+            getItems = {
+                decisionEvaluationRepository.findByStateIn(
+                    stateIn,
+                    PageRequest.of(page, perPage)
+                )
+            },
+            getCount = { decisionEvaluationRepository.countByStateIn(stateIn) }
+        )
+    }
+
+    @QueryMapping
+    fun decisionEvaluation(@Argument key: Long): DecisionEvaluation? {
+        return decisionEvaluationRepository.findByIdOrNull(key)
+    }
+
+}

--- a/graphql-api/src/main/resources/graphql/DecisionEvaluation.graphqls
+++ b/graphql-api/src/main/resources/graphql/DecisionEvaluation.graphqls
@@ -77,6 +77,19 @@ type DecisionEvaluationConnection {
     nodes: [DecisionEvaluation!]!
 }
 
+extend type Query {
+    # Find the decision evaluation with the given key.
+    decisionEvaluation(key: ID!): DecisionEvaluation
+
+    # Find all decision evaluations.
+    decisionEvaluations(
+        perPage: Int = 10,
+        page: Int = 0,
+        stateIn: [DecisionEvaluationState!] = [EVALUATED, FAILED]
+    ): DecisionEvaluationConnection!
+
+}
+
 extend type Subscription {
     # Subscribe to updates of decision evaluations (i.e. a decision was evaluated).
     decisionEvaluationUpdates(


### PR DESCRIPTION
## Description

Add a new query to the GraphQL API for decision evaluations. 

---

Query all decision evaluations:

```graphql
{
  decisionEvaluations {
    totalCount
    nodes {
      key
      decision {
        decisionId
      }
      state
      decisionOutput
      evaluationTime
    }
  }
}
```

Response:

```json
{
  "data": {
    "decisionEvaluations": {
      "totalCount": 12,
      "nodes": [
        {
          "key": "2251799813685268",
          "decision": {
            "decisionId": "department_line_manager"
          },
          "state": "EVALUATED",
          "decisionOutput": "\"Ringo\"",
          "evaluationTime": "2023-03-02T04:37:48.004Z"
        }
      ]
    }
  }
}
```

---

Related to https://github.com/camunda-community-hub/zeeqs/issues/286