### PR TITLE
fix: Add pagination on fetching evaluations for a decision

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
@@ -9,7 +9,21 @@ import org.springframework.stereotype.Repository
 @Repository
 interface DecisionEvaluationRepository : PagingAndSortingRepository<DecisionEvaluation, Long> {
 
-    fun findAllByDecisionKey(decisionKey: Long): List<DecisionEvaluation>
+    fun findAllByDecisionKey(
+        decisionKey: Long,
+        pageable: Pageable
+    ): List<DecisionEvaluation>
+
+    fun findAllByDecisionKeyAndStateIn(
+        decisionKey: Long,
+        stateIn: List<DecisionEvaluationState>,
+        pageable: Pageable
+    ): List<DecisionEvaluation>
+
+    fun countByDecisionKeyAndStateIn(
+        decisionKey: Long,
+        stateIn: List<DecisionEvaluationState>
+    ): Long
 
     fun countByDecisionKey(decisionKey: Long): Long
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/DecisionResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/DecisionResolver.kt
@@ -1,11 +1,14 @@
 package io.zeebe.zeeqs.graphql.resolvers.type
 
 import io.zeebe.zeeqs.data.entity.Decision
+import io.zeebe.zeeqs.data.entity.DecisionEvaluationState
 import io.zeebe.zeeqs.data.entity.DecisionRequirements
 import io.zeebe.zeeqs.data.repository.DecisionEvaluationRepository
 import io.zeebe.zeeqs.data.repository.DecisionRequirementsRepository
 import io.zeebe.zeeqs.graphql.resolvers.connection.DecisionEvaluationConnection
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.stereotype.Controller
 
@@ -21,11 +24,42 @@ class DecisionResolver(
     }
 
     @SchemaMapping(typeName = "Decision", field = "evaluations")
-    fun evaluations(decision: Decision): DecisionEvaluationConnection {
-        return DecisionEvaluationConnection(
-            getItems = { decisionEvaluationRepository.findAllByDecisionKey(decisionKey = decision.key) },
-            getCount = { decisionEvaluationRepository.countByDecisionKey(decisionKey = decision.key) }
-        )
+    fun evaluations(
+        decision: Decision,
+        @Argument perPage: Int,
+        @Argument page: Int,
+        @Argument stateIn: List<DecisionEvaluationState>
+    ): DecisionEvaluationConnection {
+        return if (stateIn.isEmpty()) {
+            DecisionEvaluationConnection(
+                getItems = {
+                    decisionEvaluationRepository.findAllByDecisionKey(
+                        decisionKey = decision.key,
+                        pageable = PageRequest.of(page, perPage)
+                    )
+                },
+                getCount = {
+                    decisionEvaluationRepository.countByDecisionKey(
+                        decisionKey = decision.key
+                    )
+                })
+        } else {
+            DecisionEvaluationConnection(
+                getItems = {
+                    decisionEvaluationRepository.findAllByDecisionKeyAndStateIn(
+                        decisionKey = decision.key,
+                        stateIn = stateIn,
+                        pageable = PageRequest.of(page, perPage)
+                    )
+                },
+                getCount = {
+                    decisionEvaluationRepository.countByDecisionKeyAndStateIn(
+                        decisionKey = decision.key,
+                        stateIn = stateIn
+                    )
+                }
+            )
+        }
     }
 
 }

--- a/graphql-api/src/main/resources/graphql/Decision.graphqls
+++ b/graphql-api/src/main/resources/graphql/Decision.graphqls
@@ -11,7 +11,11 @@ type Decision {
     # The decision requirements graph that contains the decision.
     decisionRequirements: DecisionRequirements
     # The evaluations of the decision.
-    evaluations: DecisionEvaluationConnection!
+    evaluations(
+        perPage: Int = 10,
+        page: Int = 0,
+        stateIn: [DecisionEvaluationState!] = [EVALUATED, FAILED]
+    ): DecisionEvaluationConnection!
 }
 
 type DecisionConnection {


### PR DESCRIPTION
## Description

Add support for pagination on fetching evaluations for a decision. 

Currently, the parameters are missing and the connection returns all evaluations. 
