### PR TITLE
fix: Add missing pagination for fetching decision evaluations

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/DecisionEvaluationRepository.kt
@@ -27,9 +27,16 @@ interface DecisionEvaluationRepository : PagingAndSortingRepository<DecisionEval
 
     fun countByDecisionKey(decisionKey: Long): Long
 
-    fun findAllByProcessInstanceKey(processInstanceKey: Long): List<DecisionEvaluation>
+    fun findAllByProcessInstanceKeyAndStateIn(
+        processInstanceKey: Long,
+        stateIn: List<DecisionEvaluationState>,
+        pageable: Pageable
+    ): List<DecisionEvaluation>
 
-    fun countByProcessInstanceKey(processInstanceKey: Long): Long
+    fun countByProcessInstanceKeyAndStateIn(
+        processInstanceKey: Long,
+        stateIn: List<DecisionEvaluationState>
+    ): Long
 
     fun findAllByElementInstanceKey(elementInstanceKey: Long): List<DecisionEvaluation>
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
@@ -152,10 +152,26 @@ class ProcessInstanceResolver(
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "decisionEvaluations")
-    fun decisionEvaluations(processInstance: ProcessInstance): DecisionEvaluationConnection {
+    fun decisionEvaluations(
+        processInstance: ProcessInstance,
+        @Argument perPage: Int,
+        @Argument page: Int,
+        @Argument stateIn: List<DecisionEvaluationState>
+    ): DecisionEvaluationConnection {
         return DecisionEvaluationConnection(
-            getItems = { decisionEvaluationRepository.findAllByProcessInstanceKey(processInstanceKey = processInstance.key) },
-            getCount = { decisionEvaluationRepository.countByProcessInstanceKey(processInstanceKey = processInstance.key) }
+            getItems = {
+                decisionEvaluationRepository.findAllByProcessInstanceKeyAndStateIn(
+                    processInstanceKey = processInstance.key,
+                    stateIn = stateIn,
+                    pageable = PageRequest.of(page, perPage)
+                )
+            },
+            getCount = {
+                decisionEvaluationRepository.countByProcessInstanceKeyAndStateIn(
+                    processInstanceKey = processInstance.key,
+                    stateIn = stateIn
+                )
+            }
         )
     }
 }

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -45,7 +45,11 @@ type ProcessInstance {
     # the opened message subscriptions related to the process instance (e.g. message catch events)
     messageSubscriptions: [MessageSubscription!]
     # The evaluated decisions that are called by a business rule task of this process instance.
-    decisionEvaluations: DecisionEvaluationConnection
+    decisionEvaluations(
+        perPage: Int = 10,
+        page: Int = 0,
+        stateIn: [DecisionEvaluationState!] = [EVALUATED, FAILED]
+    ): DecisionEvaluationConnection
     # the occurred error related to the process instance
     error: Error
 }


### PR DESCRIPTION
## Description

Add the missing pagination to the GraphQL API when fetching the decision evaluations of a process instance.

The change in the API is backward-compatible because it uses default values.