### PR TITLE
fix: Filter timers of process instance

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/TimerRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/TimerRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface TimerRepository : PagingAndSortingRepository<Timer, Long> {
 
-    fun findByProcessInstanceKey(processInstanceKey: Long): List<Timer>
+    fun findByProcessInstanceKeyAndElementInstanceKeyIsNotNull(processInstanceKey: Long): List<Timer>
 
     fun findByProcessDefinitionKeyAndElementInstanceKeyIsNull(processDefinitionKey: Long): List<Timer>
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessInstanceResolver.kt
@@ -138,7 +138,11 @@ class ProcessInstanceResolver(
 
     @SchemaMapping(typeName = "ProcessInstance", field = "timers")
     fun timers(processInstance: ProcessInstance): List<Timer> {
-        return timerRepository.findByProcessInstanceKey(processInstance.key)
+        // all timers of the process instance must have an element instance key
+        // - timers for process timer start events have a process instance key after triggered
+        return timerRepository.findByProcessInstanceKeyAndElementInstanceKeyIsNotNull(
+            processInstance.key
+        )
     }
 
     @SchemaMapping(typeName = "ProcessInstance", field = "messageSubscriptions")


### PR DESCRIPTION
## Description

A timer of a process instance must have an element instance key. It is not enough to filter by a process instance key because a timer of a process start event will have also a process instance key after it is triggered.

related to https://github.com/camunda-community-hub/zeebe-play/issues/66