### PR TITLE
deps: dump zeebe-hazelcast-exporter from 1.3.0 to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <spring.boot.version>2.7.10</spring.boot.version>
 
-    <hazelcast.exporter.version>1.3.0</hazelcast.exporter.version>
+    <hazelcast.exporter.version>1.4.0</hazelcast.exporter.version>
     <!-- pin Hazelcast version because of spring-boot-dependencies -->
     <version.hazelcast>5.2.3</version.hazelcast>
 


### PR DESCRIPTION
## Description

Dump `zeebe-hazelcast-exporter` from `1.3.0` to [1.4.0](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter/releases/tag/1.4.0).

## Related issues

