### PR TITLE
fix: Database update only

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
   graphql:
     websocket:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - spring.datasource.password=zeebe
       - spring.datasource.driverClassName=org.postgresql.Driver
       - spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-      - spring.jpa.hibernate.ddl-auto=create
+      - spring.jpa.hibernate.ddl-auto=update
     ports:
       - "9000:9000"
     depends_on:


### PR DESCRIPTION
## Description

Change the JPA Hibernate DDL-Auto property from `create` to `update`. As a result, the application doesn't drop the database tables on the start and recreate them. Instead, it tries to update the database tables and keep the data.
## Related issues

closes #357 
