### PR TITLE
feat: filter process instances by multiple variables and return bpmn groups, documentation, and extensionProperties in process details

### DIFF
--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/BpmnElementType.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/BpmnElementType.kt
@@ -25,5 +25,6 @@ enum class BpmnElementType {
     BUSINESS_RULE_TASK,
     SCRIPT_TASK,
     SEND_TASK,
-    INCLUSIVE_GATEWAY
+    INCLUSIVE_GATEWAY,
+    GROUP
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
@@ -1,0 +1,12 @@
+package io.zeebe.zeeqs.data.entity
+
+enum class EqualityOperation {
+    EQUALS,
+    CONTAINS
+}
+
+class VariableFilter (
+        val name: String,
+        val value: String,
+        val equalityOperation: EqualityOperation = EqualityOperation.EQUALS
+)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/entity/VariableFilter.kt
@@ -1,12 +1,22 @@
 package io.zeebe.zeeqs.data.entity
 
-enum class EqualityOperation {
+enum class ComparisonOperation {
     EQUALS,
     CONTAINS
+}
+
+enum class FilterOperation {
+    AND,
+    OR
 }
 
 class VariableFilter (
         val name: String,
         val value: String,
-        val equalityOperation: EqualityOperation = EqualityOperation.EQUALS
+        val comparisonOperation: ComparisonOperation = ComparisonOperation.EQUALS
+)
+
+class VariableFilterGroup (
+        val variables: List<VariableFilter>,
+        val filterOperation: FilterOperation = FilterOperation.OR
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/reactive/DataUpdatesPublisher.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/reactive/DataUpdatesPublisher.kt
@@ -18,34 +18,43 @@ class DataUpdatesPublisher {
     private val decisionEvaluationListeners = CopyOnWriteArrayList<Consumer<DecisionEvaluation>>()
 
     fun onProcessUpdated(process: Process) {
+        // Quick exit if no listeners (most common case) - Performance optimization
+        if (processListeners.isEmpty()) return
         processListeners.forEach { it.accept(process) }
     }
 
     fun onDecisionUpdated(decision: Decision) {
+        if (decisionListeners.isEmpty()) return
         decisionListeners.forEach { it.accept(decision) }
     }
 
     fun onProcessInstanceUpdated(processInstance: ProcessInstance) {
+        if (processInstanceListeners.isEmpty()) return
         processInstanceListeners.forEach { it.accept(processInstance) }
     }
 
     fun onElementInstanceUpdated(elementInstance: ElementInstance) {
+        if (elementInstanceListeners.isEmpty()) return
         elementInstanceListeners.forEach { it.accept(elementInstance) }
     }
 
     fun onVariableUpdated(variable: Variable) {
+        if (variableListeners.isEmpty()) return
         variableListeners.forEach { it.accept(variable) }
     }
 
     fun onIncidentUpdated(incident: Incident) {
+        if (incidentListeners.isEmpty()) return
         incidentListeners.forEach { it.accept(incident) }
     }
 
     fun onJobUpdated(job: Job) {
+        if (jobListeners.isEmpty()) return
         jobListeners.forEach { it.accept(job) }
     }
 
     fun onDecisionEvaluationUpdated(decisionEvaluation: DecisionEvaluation) {
+        if (decisionEvaluationListeners.isEmpty()) return
         decisionEvaluationListeners.forEach { it.accept(decisionEvaluation) }
     }
 

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/reactive/DataUpdatesPublisher.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/reactive/DataUpdatesPublisher.kt
@@ -2,19 +2,20 @@ package io.zeebe.zeeqs.data.reactive
 
 import io.zeebe.zeeqs.data.entity.*
 import org.springframework.stereotype.Component
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.function.Consumer
 
 @Component
 class DataUpdatesPublisher {
 
-    private val processListeners = mutableListOf<Consumer<Process>>()
-    private val decisionListeners = mutableListOf<Consumer<Decision>>()
-    private val processInstanceListeners = mutableListOf<Consumer<ProcessInstance>>()
-    private val elementInstanceListeners = mutableListOf<Consumer<ElementInstance>>()
-    private val variableListeners = mutableListOf<Consumer<Variable>>()
-    private val incidentListeners = mutableListOf<Consumer<Incident>>()
-    private val jobListeners = mutableListOf<Consumer<Job>>()
-    private val decisionEvaluationListeners = mutableListOf<Consumer<DecisionEvaluation>>()
+    private val processListeners = CopyOnWriteArrayList<Consumer<Process>>()
+    private val decisionListeners = CopyOnWriteArrayList<Consumer<Decision>>()
+    private val processInstanceListeners = CopyOnWriteArrayList<Consumer<ProcessInstance>>()
+    private val elementInstanceListeners = CopyOnWriteArrayList<Consumer<ElementInstance>>()
+    private val variableListeners = CopyOnWriteArrayList<Consumer<Variable>>()
+    private val incidentListeners = CopyOnWriteArrayList<Consumer<Incident>>()
+    private val jobListeners = CopyOnWriteArrayList<Consumer<Job>>()
+    private val decisionEvaluationListeners = CopyOnWriteArrayList<Consumer<DecisionEvaluation>>()
 
     fun onProcessUpdated(process: Process) {
         processListeners.forEach { it.accept(process) }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/ElementInstanceRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/ElementInstanceRepository.kt
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ElementInstanceRepository : PagingAndSortingRepository<ElementInstance, Long> {
 
+    fun findByKeyAndProcessInstanceKey(key: Long, processInstanceKey: Long): ElementInstance?
+
     fun findByProcessInstanceKey(processInstanceKey: Long): List<ElementInstance>
 
     fun findByProcessInstanceKeyAndStateIn(processInstanceKey: Long, stateIn: List<ElementInstanceState>): List<ElementInstance>

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/ProcessInstanceRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/ProcessInstanceRepository.kt
@@ -6,10 +6,16 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 
+interface ProcessInstanceKeyOnly {
+    fun getKey(): Long
+}
+
 @Repository
 interface ProcessInstanceRepository : PagingAndSortingRepository<ProcessInstance, Long> {
 
     fun findByParentProcessInstanceKey(parentProcessInstanceKey: Long): List<ProcessInstance>
+
+    fun findByProcessDefinitionKeyAndStateIn(processDefinitionKey: Long, stateIn: List<ProcessInstanceState>): List<ProcessInstanceKeyOnly>
 
     fun findByProcessDefinitionKeyAndStateIn(processDefinitionKey: Long, stateIn: List<ProcessInstanceState>, pageable: Pageable): List<ProcessInstance>
 
@@ -17,6 +23,9 @@ interface ProcessInstanceRepository : PagingAndSortingRepository<ProcessInstance
 
     fun findByStateIn(stateIn: List<ProcessInstanceState>, pageable: Pageable): List<ProcessInstance>
 
+    fun findByStateIn(stateIn: List<ProcessInstanceState>): List<ProcessInstanceKeyOnly>
+
     fun countByStateIn(stateIn: List<ProcessInstanceState>): Long
 
+    fun findByStateInAndKeyIn(stateIn: List<ProcessInstanceState>, key: List<Long>, pageable: Pageable): List<ProcessInstance>
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
@@ -1,14 +1,17 @@
 package io.zeebe.zeeqs.data.repository
 
 import io.zeebe.zeeqs.data.entity.Variable
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
+import javax.persistence.QueryHint
 
 @Repository
 interface VariableRepository : PagingAndSortingRepository<Variable, Long> {
 
     @Transactional(readOnly = true)
+    @QueryHints(value = [QueryHint(name = "org.hibernate.fetchSize", value = "1000")])
     fun findByProcessInstanceKey(processInstanceKey: Long): List<Variable>
 
     @Transactional(readOnly = true)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
@@ -17,4 +17,8 @@ interface VariableRepository : PagingAndSortingRepository<Variable, Long> {
     @Transactional(readOnly = true)
     fun findByProcessInstanceKeyInAndName(processInstanceKey: List<Long>, name: String): List<Variable>
 
+
+    @Transactional(readOnly = true)
+    fun findByProcessInstanceKeyInAndNameIn(processInstanceKey: List<Long>, name: List<String>): List<Variable>
+
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/repository/VariableRepository.kt
@@ -13,4 +13,8 @@ interface VariableRepository : PagingAndSortingRepository<Variable, Long> {
 
     @Transactional(readOnly = true)
     fun findByScopeKey(scopeKey: Long): List<Variable>
+
+    @Transactional(readOnly = true)
+    fun findByProcessInstanceKeyInAndName(processInstanceKey: List<Long>, name: String): List<Variable>
+
 }

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
@@ -1,6 +1,0 @@
-package io.zeebe.zeeqs.data.service
-
-data class BpmnElementExtensionProperties (
-    val name: String? = null,
-    val value: String? = null,
-)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementExtensionProperties.kt
@@ -1,0 +1,6 @@
+package io.zeebe.zeeqs.data.service
+
+data class BpmnElementExtensionProperties (
+    val name: String? = null,
+    val value: String? = null,
+)

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
@@ -1,10 +1,14 @@
 package io.zeebe.zeeqs.data.service
 
+import io.camunda.zeebe.model.bpmn.instance.Documentation
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty
 import io.zeebe.zeeqs.data.entity.BpmnElementType
 
 data class BpmnElementInfo(
         val elementId: String,
         val elementName: String?,
         val elementType: BpmnElementType,
-        val metadata: BpmnElementMetadata
+        val metadata: BpmnElementMetadata,
+        val extensionProperties: Collection<BpmnElementExtensionProperties>?,
+        val documentation: String?
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnElementInfo.kt
@@ -1,7 +1,5 @@
 package io.zeebe.zeeqs.data.service
 
-import io.camunda.zeebe.model.bpmn.instance.Documentation
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty
 import io.zeebe.zeeqs.data.entity.BpmnElementType
 
 data class BpmnElementInfo(
@@ -9,6 +7,6 @@ data class BpmnElementInfo(
         val elementName: String?,
         val elementType: BpmnElementType,
         val metadata: BpmnElementMetadata,
-        val extensionProperties: Collection<BpmnElementExtensionProperties>?,
+        val extensionElements: BpmnExtensionElements?,
         val documentation: String?
 )

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnExtensionElements.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/BpmnExtensionElements.kt
@@ -1,0 +1,20 @@
+package io.zeebe.zeeqs.data.service
+
+data class BpmnExtensionProperty(
+        val name: String?,
+        val value: String?
+)
+
+data class IoMapping (
+        val source: String?,
+        val target: String?
+)
+data class ExtensionIoMapping(
+        val inputs: List<IoMapping>? = emptyList(),
+        val outputs: List<IoMapping>? = emptyList(),
+)
+data class BpmnExtensionElements(
+        val properties: List<BpmnExtensionProperty>? = emptyList(),
+        val ioMapping: ExtensionIoMapping? = ExtensionIoMapping(),
+)
+

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
@@ -1,0 +1,79 @@
+package io.zeebe.zeeqs.data.service
+
+import io.zeebe.zeeqs.data.entity.ProcessInstance
+import io.zeebe.zeeqs.data.entity.ProcessInstanceState
+import io.zeebe.zeeqs.data.entity.Variable
+import io.zeebe.zeeqs.data.repository.ProcessInstanceKeyOnly
+import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
+import io.zeebe.zeeqs.data.repository.VariableRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+
+@Component
+class ProcessInstanceService(
+        private val processInstancesRepository: ProcessInstanceRepository,
+        private val variableRepository: VariableRepository) {
+
+    private fun getVariables(stateIn: List<ProcessInstanceState>, variableName: String, variableValue: String): List<Variable> {
+        val processInstances = processInstancesRepository.findByStateIn(stateIn).toList();
+        return getVariablesByProcessInstanceKeys(processInstances, variableName, variableValue);
+    }
+
+    private fun getVariables(stateIn: List<ProcessInstanceState>, processDefinitionKey: Long, variableName: String, variableValue: String): List<Variable> {
+        val processInstances = processInstancesRepository.findByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn).toList();
+        return getVariablesByProcessInstanceKeys(processInstances, variableName, variableValue);
+
+    }
+
+    private fun getVariablesByProcessInstanceKeys(processInstances: List<ProcessInstanceKeyOnly>, variableName: String, variableValue: String): List<Variable> {
+        val variables = variableRepository.findByProcessInstanceKeyInAndName(processInstances.map { it.getKey() }, variableName);
+        val filteredVariables = variables.filter { it.value == variableValue };
+        return filteredVariables;
+    }
+
+    fun getProcessInstances(perPage: Int, page: Int, stateIn: List<ProcessInstanceState>, variableName: String?, variableValue: String?): List<ProcessInstance> {
+        if(variableName != null && variableValue != null) {
+            val filteredVariables = getVariables(stateIn, variableName, variableValue);
+            val filteredProcessInstances = processInstancesRepository.findByStateInAndKeyIn(stateIn, filteredVariables.map { it.processInstanceKey }, PageRequest.of(page, perPage)).toList();
+            return filteredProcessInstances;
+        }
+        else {
+            return processInstancesRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList();
+        }
+    }
+
+    fun countProcessInstances(stateIn: List<ProcessInstanceState>, variableName: String?, variableValue: String?): Long {
+        if(variableName != null && variableValue != null) {
+            val filteredVariables = getVariables(stateIn, variableName, variableValue);
+            return filteredVariables.count().toLong();
+        }
+
+        else {
+            return processInstancesRepository.countByStateIn(stateIn);
+        }
+    }
+
+
+    fun getProcessInstances(perPage: Int, page: Int, stateIn: List<ProcessInstanceState>, processDefinitionKey: Long, variableName: String?, variableValue: String?): List<ProcessInstance> {
+        if(variableName != null && variableValue != null) {
+            val filteredVariables = getVariables(stateIn, processDefinitionKey, variableName, variableValue);
+            val filteredProcessInstances = processInstancesRepository.findByStateInAndKeyIn(stateIn, filteredVariables.map { it.processInstanceKey }, PageRequest.of(page, perPage)).toList();
+            return filteredProcessInstances;
+        }
+        else {
+            return processInstancesRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList();
+        }
+    }
+
+    fun countProcessInstances(stateIn: List<ProcessInstanceState>, processDefinitionKey: Long, variableName: String?, variableValue: String?): Long {
+        if(variableName != null && variableValue != null) {
+            val filteredVariables = getVariables(stateIn, processDefinitionKey, variableName, variableValue);
+            return filteredVariables.count().toLong();
+        }
+
+        else {
+            return processInstancesRepository.countByStateIn(stateIn);
+        }
+    }
+
+}

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessInstanceService.kt
@@ -61,7 +61,7 @@ class ProcessInstanceService(
             return filteredProcessInstances;
         }
         else {
-            return processInstancesRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList();
+            return processInstancesRepository.findByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn, PageRequest.of(page, perPage)).toList();
         }
     }
 
@@ -72,7 +72,7 @@ class ProcessInstanceService(
         }
 
         else {
-            return processInstancesRepository.countByStateIn(stateIn);
+            return processInstancesRepository.countByProcessDefinitionKeyAndStateIn(processDefinitionKey, stateIn);
         }
     }
 

--- a/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
+++ b/data/src/main/kotlin/io/zeebe/zeeqs/data/service/ProcessService.kt
@@ -168,11 +168,15 @@ class ProcessService(val processRepository: ProcessRepository) {
     }
 
     private fun getExtensionProperties(element: BaseElement): Collection<BpmnElementExtensionProperties>? {
-       return element.extensionElements?.elementsQuery
+        return element.extensionElements?.elementsQuery
                 ?.filterByType(ZeebeProperties::class.java)
-                ?.singleResult()
-                ?.properties
-                ?.map { BpmnElementExtensionProperties(name = it.name, value = it.value) }
+                ?.findSingleResult()
+                ?.map { properties ->
+                    properties.properties?.map { property ->
+                        BpmnElementExtensionProperties(name = property.name, value = property.value)
+                    }
+                }
+                ?.orElse(null)
     }
 
 

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import java.time.Instant
@@ -52,12 +51,12 @@ class ProcessServiceTest(
             // then
             assertThat(info)
                     .isNotNull()
-                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), null, "")))
-                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), null, "")))
+                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), BpmnExtensionElements(properties = emptyList(), ioMapping = ExtensionIoMapping()), "")))
+                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), BpmnExtensionElements(properties = emptyList(), ioMapping = ExtensionIoMapping()), "")))
                     .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
-                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), null, ""))
+                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), BpmnExtensionElements(properties = emptyList(), ioMapping = ExtensionIoMapping()), ""))
                     )
-                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), null, "")))
+                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), BpmnExtensionElements(properties = emptyList(), ioMapping = ExtensionIoMapping()), "")))
         }
 
         @Test
@@ -91,7 +90,8 @@ class ProcessServiceTest(
                                                     resource = """{"x":1}"""
                                             )
                                     ),
-                                    null, ""
+                                    BpmnExtensionElements(properties = emptyList(), ioMapping = ExtensionIoMapping()),
+                                    ""
                             )
                     )
         }

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -52,12 +52,12 @@ class ProcessServiceTest(
             // then
             assertThat(info)
                     .isNotNull()
-                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
-                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), null, "")))
+                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), null, "")))
                     .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
-                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), listOf(BpmnElementExtensionProperties()), ""))
+                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), null, ""))
                     )
-                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), null, "")))
         }
 
         @Test
@@ -91,7 +91,7 @@ class ProcessServiceTest(
                                                     resource = """{"x":1}"""
                                             )
                                     ),
-                                    listOf(BpmnElementExtensionProperties()), ""
+                                    null, ""
                             )
                     )
         }

--- a/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
+++ b/data/src/test/kotlin/io/zeebe/zeeqs/ProcessServiceTest.kt
@@ -52,12 +52,12 @@ class ProcessServiceTest(
             // then
             assertThat(info)
                     .isNotNull()
-                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata())))
-                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"))))
+                    .contains(entry("s", BpmnElementInfo("s", "start", BpmnElementType.START_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
+                    .contains(entry("t", BpmnElementInfo("t", "task", BpmnElementType.SERVICE_TASK, BpmnElementMetadata(jobType = "test"), listOf(BpmnElementExtensionProperties()), "")))
                     .contains(entry("u", BpmnElementInfo("u", "userTask", BpmnElementType.USER_TASK, BpmnElementMetadata(
-                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1"))))
+                            userTaskAssignmentDefinition = UserTaskAssignmentDefinition(assignee = "user1", candidateGroups = "group1")), listOf(BpmnElementExtensionProperties()), ""))
                     )
-                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata())))
+                    .contains(entry("e", BpmnElementInfo("e", null, BpmnElementType.END_EVENT, BpmnElementMetadata(), listOf(BpmnElementExtensionProperties()), "")))
         }
 
         @Test
@@ -90,7 +90,8 @@ class ProcessServiceTest(
                                                     key = "camunda-forms:bpmn:form_A",
                                                     resource = """{"x":1}"""
                                             )
-                                    )
+                                    ),
+                                    listOf(BpmnElementExtensionProperties()), ""
                             )
                     )
         }

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
@@ -2,7 +2,7 @@ package io.zeebe.zeeqs.graphql.resolvers.query
 
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstanceState
-import io.zeebe.zeeqs.data.entity.VariableFilter
+import io.zeebe.zeeqs.data.entity.VariableFilterGroup
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.service.ProcessInstanceService
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
@@ -23,11 +23,11 @@ class ProcessInstanceQueryResolver(
             @Argument perPage: Int,
             @Argument page: Int,
             @Argument stateIn: List<ProcessInstanceState>,
-            @Argument variables: List<VariableFilter>?
+            @Argument variablesFilter: VariableFilterGroup?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
-                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variables) },
-                getCount = { processInstanceService.countProcessInstances(stateIn, variables) }
+                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variablesFilter) },
+                getCount = { processInstanceService.countProcessInstances(stateIn, variablesFilter) }
         )
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
@@ -2,6 +2,7 @@ package io.zeebe.zeeqs.graphql.resolvers.query
 
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstanceState
+import io.zeebe.zeeqs.data.entity.VariableFilter
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.service.ProcessInstanceService
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
@@ -22,12 +23,11 @@ class ProcessInstanceQueryResolver(
             @Argument perPage: Int,
             @Argument page: Int,
             @Argument stateIn: List<ProcessInstanceState>,
-            @Argument variableName: String?,
-            @Argument variableValue: String?
+            @Argument variables: List<VariableFilter>?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
-                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variableName, variableValue) },
-                getCount = { processInstanceService.countProcessInstances(stateIn, variableName, variableValue) }
+                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variables) },
+                getCount = { processInstanceService.countProcessInstances(stateIn, variables) }
         )
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/query/ProcessInstanceQueryResolver.kt
@@ -3,6 +3,7 @@ package io.zeebe.zeeqs.graphql.resolvers.query
 import io.zeebe.zeeqs.data.entity.ProcessInstance
 import io.zeebe.zeeqs.data.entity.ProcessInstanceState
 import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
+import io.zeebe.zeeqs.data.service.ProcessInstanceService
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
@@ -12,18 +13,21 @@ import org.springframework.stereotype.Controller
 
 @Controller
 class ProcessInstanceQueryResolver(
-        val processInstanceRepository: ProcessInstanceRepository
+        val processInstanceRepository: ProcessInstanceRepository,
+        val processInstanceService: ProcessInstanceService
 ) {
 
     @QueryMapping
     fun processInstances(
             @Argument perPage: Int,
             @Argument page: Int,
-            @Argument stateIn: List<ProcessInstanceState>
+            @Argument stateIn: List<ProcessInstanceState>,
+            @Argument variableName: String?,
+            @Argument variableValue: String?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
-                getItems = { processInstanceRepository.findByStateIn(stateIn, PageRequest.of(page, perPage)).toList() },
-                getCount = { processInstanceRepository.countByStateIn(stateIn) }
+                getItems = { processInstanceService.getProcessInstances(perPage, page, stateIn, variableName, variableValue) },
+                getCount = { processInstanceService.countProcessInstances(stateIn, variableName, variableValue) }
         )
     }
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
@@ -5,10 +5,7 @@ import io.zeebe.zeeqs.data.entity.ElementInstanceState
 import io.zeebe.zeeqs.data.entity.Process
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessRepository
-import io.zeebe.zeeqs.data.service.BpmnElementExtensionProperties
-import io.zeebe.zeeqs.data.service.BpmnElementInfo
-import io.zeebe.zeeqs.data.service.BpmnElementMetadata
-import io.zeebe.zeeqs.data.service.ProcessService
+import io.zeebe.zeeqs.data.service.*
 import io.zeebe.zeeqs.graphql.resolvers.connection.ElementInstanceConnection
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
@@ -43,10 +40,10 @@ class BpmnElementResolver(
     }
 
 
-    @SchemaMapping(typeName = "BpmnElement", field = "extensionProperties")
-    fun extensionProperties(element: BpmnElement): Collection<BpmnElementExtensionProperties>? {
+    @SchemaMapping(typeName = "BpmnElement", field = "extensionElements")
+    fun extensionElements(element: BpmnElement): BpmnExtensionElements? {
         return findElementInfo(element)
-                ?.extensionProperties
+                ?.extensionElements
     }
 
 

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/BpmnElementResolver.kt
@@ -5,6 +5,7 @@ import io.zeebe.zeeqs.data.entity.ElementInstanceState
 import io.zeebe.zeeqs.data.entity.Process
 import io.zeebe.zeeqs.data.repository.ElementInstanceRepository
 import io.zeebe.zeeqs.data.repository.ProcessRepository
+import io.zeebe.zeeqs.data.service.BpmnElementExtensionProperties
 import io.zeebe.zeeqs.data.service.BpmnElementInfo
 import io.zeebe.zeeqs.data.service.BpmnElementMetadata
 import io.zeebe.zeeqs.data.service.ProcessService
@@ -39,6 +40,21 @@ class BpmnElementResolver(
         return findElementInfo(element)
                 ?.metadata
                 ?: BpmnElementMetadata()
+    }
+
+
+    @SchemaMapping(typeName = "BpmnElement", field = "extensionProperties")
+    fun extensionProperties(element: BpmnElement): Collection<BpmnElementExtensionProperties>? {
+        return findElementInfo(element)
+                ?.extensionProperties
+    }
+
+
+    @SchemaMapping(typeName = "BpmnElement", field = "documentation")
+    fun documentation(element: BpmnElement): String? {
+        return findElementInfo(element)
+                ?.documentation
+
     }
 
     @SchemaMapping(typeName = "BpmnElement", field = "process")

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
@@ -30,8 +30,7 @@ class ProcessResolver(
         @Argument perPage: Int,
         @Argument page: Int,
         @Argument stateIn: List<ProcessInstanceState>,
-        @Argument variableName: String?,
-        @Argument variableValue: String?
+        @Argument variables: List<VariableFilter>?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
             getItems = {
@@ -40,16 +39,14 @@ class ProcessResolver(
                         page,
                         stateIn,
                         process.key,
-                        variableName,
-                        variableValue
+                        variables
                 ).toList()
             },
             getCount = {
                 processInstanceService.countProcessInstances(
                         stateIn,
                         process.key,
-                        variableName,
-                        variableValue
+                        variables
                 )
             }
         )

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
@@ -30,7 +30,7 @@ class ProcessResolver(
         @Argument perPage: Int,
         @Argument page: Int,
         @Argument stateIn: List<ProcessInstanceState>,
-        @Argument variables: List<VariableFilter>?
+        @Argument variablesFilter: VariableFilterGroup?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
             getItems = {
@@ -39,14 +39,14 @@ class ProcessResolver(
                         page,
                         stateIn,
                         process.key,
-                        variables
+                        variablesFilter
                 ).toList()
             },
             getCount = {
                 processInstanceService.countProcessInstances(
                         stateIn,
                         process.key,
-                        variables
+                        variablesFilter
                 )
             }
         )

--- a/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
+++ b/graphql-api/src/main/kotlin/io/zeebe/zeeqs/graphql/resolvers/type/ProcessResolver.kt
@@ -6,6 +6,7 @@ import io.zeebe.zeeqs.data.repository.ProcessInstanceRepository
 import io.zeebe.zeeqs.data.repository.SignalSubscriptionRepository
 import io.zeebe.zeeqs.data.repository.TimerRepository
 import io.zeebe.zeeqs.data.service.BpmnElementInfo
+import io.zeebe.zeeqs.data.service.ProcessInstanceService
 import io.zeebe.zeeqs.data.service.ProcessService
 import io.zeebe.zeeqs.graphql.resolvers.connection.ProcessInstanceConnection
 import org.springframework.data.domain.PageRequest
@@ -19,6 +20,7 @@ class ProcessResolver(
     val timerRepository: TimerRepository,
     val messageSubscriptionRepository: MessageSubscriptionRepository,
     val processService: ProcessService,
+    val processInstanceService: ProcessInstanceService,
     private val signalSubscriptionRepository: SignalSubscriptionRepository
 ) {
 
@@ -27,20 +29,27 @@ class ProcessResolver(
         process: Process,
         @Argument perPage: Int,
         @Argument page: Int,
-        @Argument stateIn: List<ProcessInstanceState>
+        @Argument stateIn: List<ProcessInstanceState>,
+        @Argument variableName: String?,
+        @Argument variableValue: String?
     ): ProcessInstanceConnection {
         return ProcessInstanceConnection(
             getItems = {
-                processInstanceRepository.findByProcessDefinitionKeyAndStateIn(
-                    process.key,
-                    stateIn,
-                    PageRequest.of(page, perPage)
+                processInstanceService.getProcessInstances(
+                        perPage,
+                        page,
+                        stateIn,
+                        process.key,
+                        variableName,
+                        variableValue
                 ).toList()
             },
             getCount = {
-                processInstanceRepository.countByProcessDefinitionKeyAndStateIn(
-                    process.key,
-                    stateIn
+                processInstanceService.countProcessInstances(
+                        stateIn,
+                        process.key,
+                        variableName,
+                        variableValue
                 )
             }
         )

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -11,7 +11,7 @@ type BpmnElement {
     metadata: BpmnElementMetadata!
 
     # extension properties of the BPMN element
-    extensionProperties:  [BpmnElementExtensionProperties]
+    extensionElements:  BpmnExtensionElements
 
     # documentation of the BPMN element
     documentation: String
@@ -93,9 +93,22 @@ type UserTaskAssignmentDefinition {
     candidateGroups: String
 }
 
-type BpmnElementExtensionProperties {
-    # the name of property
-    name: String
-    # the value of property
-    value: String
+type BpmnExtensionProperty {
+  name: String
+  value: String
+}
+
+type IoMapping {
+  source: String
+  target: String
+}
+
+type ExtensionIoMapping {
+  inputs: [IoMapping]
+  outputs: [IoMapping]
+}
+
+type BpmnExtensionElements {
+  properties: [BpmnExtensionProperty]
+  ioMapping: ExtensionIoMapping
 }

--- a/graphql-api/src/main/resources/graphql/Element.graphqls
+++ b/graphql-api/src/main/resources/graphql/Element.graphqls
@@ -10,6 +10,12 @@ type BpmnElement {
     # the metadata of the BPMN element
     metadata: BpmnElementMetadata!
 
+    # extension properties of the BPMN element
+    extensionProperties:  [BpmnElementExtensionProperties]
+
+    # documentation of the BPMN element
+    documentation: String
+
     # the process that contains the BPMN element
     process: Process
     # the instances of the BPMN element
@@ -46,6 +52,7 @@ enum BpmnElementType {
     SCRIPT_TASK
     SEND_TASK
     INCLUSIVE_GATEWAY
+    GROUP
 }
 
 # Additional metadata that are defined statically on the BPMN element.
@@ -84,4 +91,11 @@ type UserTaskAssignmentDefinition {
     assignee: String
     # the candidate groups
     candidateGroups: String
+}
+
+type BpmnElementExtensionProperties {
+    # the name of property
+    name: String
+    # the value of property
+    value: String
 }

--- a/graphql-api/src/main/resources/graphql/Process.graphqls
+++ b/graphql-api/src/main/resources/graphql/Process.graphqls
@@ -14,7 +14,7 @@ type Process {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]
-        variables: [VariableFilter] = null): ProcessInstanceConnection!
+        variablesFilter: VariableFilterGroup = null): ProcessInstanceConnection!
     # the scheduled timers of the timer start events of the process
     timers: [Timer!]
     # the opened message subscriptions of the message start events of the process

--- a/graphql-api/src/main/resources/graphql/Process.graphqls
+++ b/graphql-api/src/main/resources/graphql/Process.graphqls
@@ -14,8 +14,7 @@ type Process {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]
-        variableName: String = null,
-        variableValue: String = null): ProcessInstanceConnection!
+        variables: [VariableFilter] = null): ProcessInstanceConnection!
     # the scheduled timers of the timer start events of the process
     timers: [Timer!]
     # the opened message subscriptions of the message start events of the process

--- a/graphql-api/src/main/resources/graphql/Process.graphqls
+++ b/graphql-api/src/main/resources/graphql/Process.graphqls
@@ -13,7 +13,9 @@ type Process {
     processInstances(
         perPage: Int = 10,
         page: Int = 0,
-        stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]): ProcessInstanceConnection!
+        stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]
+        variableName: String = null,
+        variableValue: String = null): ProcessInstanceConnection!
     # the scheduled timers of the timer start events of the process
     timers: [Timer!]
     # the opened message subscriptions of the message start events of the process

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -74,7 +74,7 @@ type Query {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED],
-        variables: [VariableFilter] = null
+        variablesFilter: VariableFilterGroup = null
     ): ProcessInstanceConnection!
 
 }

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -74,8 +74,7 @@ type Query {
         perPage: Int = 10,
         page: Int = 0,
         stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED],
-        variableName: String = null,
-        variableValue: String = null
+        variables: [VariableFilter] = null
     ): ProcessInstanceConnection!
 
 }

--- a/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
+++ b/graphql-api/src/main/resources/graphql/ProcessInstance.graphqls
@@ -73,7 +73,9 @@ type Query {
     processInstances(
         perPage: Int = 10,
         page: Int = 0,
-        stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED]
+        stateIn: [ProcessInstanceState!] = [ACTIVATED, COMPLETED, TERMINATED],
+        variableName: String = null,
+        variableValue: String = null
     ): ProcessInstanceConnection!
 
 }

--- a/graphql-api/src/main/resources/graphql/Variable.graphqls
+++ b/graphql-api/src/main/resources/graphql/Variable.graphqls
@@ -14,3 +14,15 @@ type VariableUpdate {
     value: String!
     timestamp(zoneId: String = "Z"): String!
 }
+
+input VariableFilter {
+    name: String!,
+    value: String!,
+    equalityOperation: EqualityOperation = EQUALS
+}
+
+# The type of a variable value filter
+enum EqualityOperation {
+    EQUALS,
+    CONTAINS
+}

--- a/graphql-api/src/main/resources/graphql/Variable.graphqls
+++ b/graphql-api/src/main/resources/graphql/Variable.graphqls
@@ -18,11 +18,20 @@ type VariableUpdate {
 input VariableFilter {
     name: String!,
     value: String!,
-    equalityOperation: EqualityOperation = EQUALS
+    comparisonOperation: ComparisonOperation!
 }
 
-# The type of a variable value filter
-enum EqualityOperation {
+input VariableFilterGroup {
+    variables: [VariableFilter!]
+    filterOperation: FilterOperation = OR
+}
+
+enum ComparisonOperation {
     EQUALS,
     CONTAINS
+}
+
+enum FilterOperation {
+    AND,
+    OR
 }

--- a/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
+++ b/hazelcast-importer/src/main/kotlin/io/zeebe/zeeqs/importer/hazelcast/HazelcastImporter.kt
@@ -10,7 +10,6 @@ import io.zeebe.zeeqs.data.entity.*
 import io.zeebe.zeeqs.data.reactive.DataUpdatesPublisher
 import io.zeebe.zeeqs.data.repository.*
 import io.zeebe.zeeqs.importer.hazelcast.ProtobufTransformer.structToMap
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.Duration
 
@@ -36,15 +35,6 @@ class HazelcastImporter(
     private val signalImporter: HazelcastSignalImporter,
     private val dataUpdatesPublisher: DataUpdatesPublisher
 ) {
-
-    private val logger = LoggerFactory.getLogger(HazelcastImporter::class.java)
-
-    // Offset for generating synthetic keys when Zeebe reuses element instance keys
-    // Using a large offset to avoid conflicts with real Zeebe keys
-    private val SYNTHETIC_KEY_OFFSET = 9000000000000000L
-    
-    // Counter for generating unique synthetic keys when there are multiple collisions
-    private val syntheticKeyCounter = java.util.concurrent.atomic.AtomicLong(0)
 
     var zeebeHazelcast: ZeebeHazelcast? = null
 
@@ -230,41 +220,9 @@ class HazelcastImporter(
     }
 
     private fun importElementInstance(record: Schema.ProcessInstanceRecord) {
-        val existingEntity = elementInstanceRepository.findById(record.metadata.key)
-        
-        val entity = if (existingEntity.isPresent) {
-            val existing = existingEntity.get()
-            // Check if this is the same element or if the key was reused for a different element
-            if (existing.elementId == record.elementId) {
-                // Same element - update it (state transitions like ACTIVATING → COMPLETED)
-                existing
-            } else {
-                // Different element with same key - Zeebe has reused the key
-                // Create new element instance with synthetic key instead of skipping
-                val isSameProcess = existing.processInstanceKey == record.processInstanceKey
-                
-                if (isSameProcess) {
-                    logger.warn(
-                        "ElementInstance key {} reused within SAME process instance. " +
-                        "Existing: PI={}, elementId={}. New: PI={}, elementId={}. Creating synthetic key.",
-                        record.metadata.key, existing.processInstanceKey, existing.elementId,
-                        record.processInstanceKey, record.elementId
-                    )
-                } else {
-                    logger.info(
-                        "ElementInstance key {} reused across process instances. " +
-                        "Existing: PI={}, elementId={}. New: PI={}, elementId={}. Creating synthetic key.",
-                        record.metadata.key, existing.processInstanceKey, existing.elementId,
-                        record.processInstanceKey, record.elementId
-                    )
-                }
-                
-                createElementInstanceWithSyntheticKey(record)
-            }
-        } else {
-            // New element instance - use original Zeebe key
-            createElementInstance(record)
-        }
+        val entity = elementInstanceRepository
+            .findById(record.metadata.key)
+            .orElse(createElementInstance(record))
 
         entity.state = getElementInstanceState(record)
 
@@ -286,40 +244,9 @@ class HazelcastImporter(
         elementInstanceRepository.save(entity)
         dataUpdatesPublisher.onElementInstanceUpdated(entity)
     }
-    
-    private fun createElementInstanceWithSyntheticKey(record: Schema.ProcessInstanceRecord): ElementInstance {
-        // Generate a synthetic key that won't conflict with Zeebe keys
-        // We use a large offset plus a counter to ensure uniqueness
-        val syntheticKey = SYNTHETIC_KEY_OFFSET + record.metadata.key + syntheticKeyCounter.incrementAndGet()
-        
-        // Check if synthetic key already exists (unlikely but possible)
-        var finalKey = syntheticKey
-        var attempt = 0
-        while (elementInstanceRepository.findById(finalKey).isPresent && attempt < 10) {
-            finalKey = SYNTHETIC_KEY_OFFSET + record.metadata.key + syntheticKeyCounter.incrementAndGet()
-            attempt++
-        }
-        
-        if (attempt >= 10) {
-            logger.error(
-                "Failed to generate unique synthetic key for element instance after 10 attempts. " +
-                "Original key: {}, elementId: {}", 
-                record.metadata.key, record.elementId
-            )
-            throw IllegalStateException("Unable to generate unique synthetic key for element instance")
-        }
-        
-        logger.debug(
-            "Created element instance with synthetic key {} (original Zeebe key: {}, elementId: {})",
-            finalKey, record.metadata.key, record.elementId
-        )
-        
-        // Reuse createElementInstance with custom synthetic key
-        return createElementInstance(record, customKey = finalKey)
-    }
 
-    private fun mapBpmnElementType(bpmnElementTypeString: String): BpmnElementType {
-        return when (bpmnElementTypeString) {
+    private fun createElementInstance(record: Schema.ProcessInstanceRecord): ElementInstance {
+        val bpmnElementType = when (record.bpmnElementType) {
             "UNSPECIFIED" -> BpmnElementType.UNSPECIFIED
             "BOUNDARY_EVENT" -> BpmnElementType.BOUNDARY_EVENT
             "CALL_ACTIVITY" -> BpmnElementType.CALL_ACTIVITY
@@ -345,13 +272,9 @@ class HazelcastImporter(
             "INCLUSIVE_GATEWAY" -> BpmnElementType.INCLUSIVE_GATEWAY
             else -> BpmnElementType.UNKNOWN
         }
-    }
-    
-    private fun createElementInstance(record: Schema.ProcessInstanceRecord, customKey: Long? = null): ElementInstance {
-        val bpmnElementType = mapBpmnElementType(record.bpmnElementType)
 
         return ElementInstance(
-            key = customKey ?: record.metadata.key,  // Use custom key if provided, otherwise use record key
+            key = record.metadata.key,
             position = record.metadata.position,
             elementId = record.elementId,
             bpmnElementType = bpmnElementType,


### PR DESCRIPTION
## Description

This PR adds the following features:

* Allows filtering process instances by process variables:

```
{
  process(key: 2251799813712348){
    key
    processInstances(variablesFilter: {
      variables : [
      {
        name: "userEmail", 
        value:"myemail@gmail.com",
        comparisonOperation: EQUALS
      },
      {
        name: "processType", 
        value:"My Process Type",
        comparisonOperation: CONTAINS
      }          
      ],
      filterOperation: OR
    }
    ) {
      totalCount
      nodes {
        key
        variables(globalOnly: true){
           name
          value
        }
      }
    }
  }
}
```

* Return documentation and extensionProperties along with process elements. In addition, allow returning `bpmn:group` elements since before it was only returning elements of type FlowElement

```
{
  process(key: 2251799813712348){
    key
    elements {
      elementId
      bpmnElementType
      extensionProperties {
        name
        value
      }
      documentation
    }
  }
}
```

## Related issues

For filtering by variables: 
closes # https://github.com/camunda-community-hub/zeeqs/issues/16

For returning documentation, group, and extensionProperties:
closes # https://github.com/camunda-community-hub/zeeqs/issues/356